### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,4 +1,6 @@
 name: Run tests and upload coverage
+permissions:
+  contents: read
 
 on:
   - push


### PR DESCRIPTION
Potential fix for [https://github.com/lzm0x219/ziwei/security/code-scanning/1](https://github.com/lzm0x219/ziwei/security/code-scanning/1)

To remediate this problem, you should explicitly add a `permissions:` block to the workflow, choosing the minimum level of access required for the workflow to succeed. Since all steps are reading repository content and uploading to external services (Codecov), it's sufficient to set `contents: read` permissions. Place this block at the top level (after the `name:` and before or after the `on:` block), applying the restriction to all jobs unless a more permissive block is needed within a specific job (not applicable here).

No additional methods, imports, or definitions are required—just YAML edits in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
