### PR TITLE
refactor: borrow Ziwei queries

### DIFF
--- a/crates/ziwei/src/ziwei.rs
+++ b/crates/ziwei/src/ziwei.rs
@@ -31,9 +31,11 @@ use super::{
 
 /// 可供调用者查询的紫微斗数命盘对象（本命真相源）。
 ///
-/// 体积固定、`Copy`，适合按值传递；星位与飞边在构造时算完。
+/// 体积固定且较大（含十二宫、十八星、48 条飞边与十二步大限），仅 [`Clone`]，
+/// **不**实现 [`Copy`]；查询方法一律借用 `&self`，需要副本时显式调用
+/// [`Clone::clone`]。星位与飞边在构造时算完。
 /// 大限/流年查询一律传入 [`ZiweiView`]，不提供第二份盘或句柄类型。
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Ziwei {
     /// 十二本命宫（职/支/干）。
     palaces: Palaces,
@@ -108,7 +110,7 @@ impl Ziwei {
     }
 
     /// 身宫所叠地支。
-    pub const fn shen_branch(self) -> Branch {
+    pub const fn shen_branch(&self) -> Branch {
         self.shen_branch
     }
 
@@ -118,29 +120,29 @@ impl Ziwei {
     }
 
     /// 命宫五行局。
-    pub const fn bureau(self) -> FiveElementBureau {
+    pub const fn bureau(&self) -> FiveElementBureau {
         self.bureau
     }
 
     /// 生年天干。
-    pub const fn birth_stem(self) -> Stem {
+    pub const fn birth_stem(&self) -> Stem {
         self.birth_stem
     }
 
     /// 生年地支。
-    pub const fn birth_branch(self) -> Branch {
+    pub const fn birth_branch(&self) -> Branch {
         self.birth_branch
     }
 
     /// 真实农历出生年序号。
     ///
     /// [`Self::from_birth`] 返回 `Some(year)`；仅有生年干支的 [`Self::from_input`] 返回 `None`。
-    pub const fn birth_year(self) -> Option<i32> {
+    pub const fn birth_year(&self) -> Option<i32> {
         self.birth_year
     }
 
     /// 性别。
-    pub const fn gender(self) -> Gender {
+    pub const fn gender(&self) -> Gender {
         self.gender
     }
 
@@ -152,22 +154,22 @@ impl Ziwei {
     }
 
     /// 星曜落宫支。
-    pub const fn branch_of_star(self, star: Star) -> Branch {
+    pub const fn branch_of_star(&self, star: Star) -> Branch {
         self.star_branches[star.index()]
     }
 
     /// 来因宫地支。
-    pub const fn laiyin_branch(self) -> Branch {
+    pub const fn laiyin_branch(&self) -> Branch {
         self.birth_stem.laiyin_branch()
     }
 
     /// 生年四化（固定，不随视图变）。
-    pub fn year_transformations(self) -> [LayerTransformation; 4] {
+    pub fn year_transformations(&self) -> [LayerTransformation; 4] {
         self.stem_transformations(self.birth_stem)
     }
 
     /// 任意天干的层四化：四星及其在本命盘上的落宫（ADR-0003）。
-    pub fn stem_transformations(self, stem: Stem) -> [LayerTransformation; 4] {
+    pub fn stem_transformations(&self, stem: Stem) -> [LayerTransformation; 4] {
         stem_layer_transformations(stem, &self.star_branches)
     }
 
@@ -182,7 +184,7 @@ impl Ziwei {
     }
 
     /// 虚岁落在哪一步大限。
-    pub fn decade_step_for_age(self, virtual_age: u8) -> Option<DecadeIndex> {
+    pub fn decade_step_for_age(&self, virtual_age: u8) -> Option<DecadeIndex> {
         self.decade_steps
             .iter()
             .find(|step| (step.age_start..=step.age_end).contains(&virtual_age))
@@ -195,7 +197,10 @@ impl Ziwei {
     ///
     /// 没有真实出生年时返回 [`DecadeYearsError::BirthYearUnavailable`]；任一流年超出
     /// [`i32`] 可表示范围时返回 [`DecadeYearsError::LunarYearOutOfRange`]。
-    pub fn years_in_decade(self, index: DecadeIndex) -> Result<[DecadeYear; 10], DecadeYearsError> {
+    pub fn years_in_decade(
+        &self,
+        index: DecadeIndex,
+    ) -> Result<[DecadeYear; 10], DecadeYearsError> {
         let birth_year = self
             .birth_year
             .ok_or(DecadeYearsError::BirthYearUnavailable)?;
@@ -218,8 +223,7 @@ impl Ziwei {
     }
 
     /// 视图下宫职对应的地支。
-    ///
-    pub fn branch_of_role(self, role: PalaceRole, view: ZiweiView) -> Branch {
+    pub fn branch_of_role(&self, role: PalaceRole, view: ZiweiView) -> Branch {
         let ming = self.view_ming_branch(view);
         Branch::from_index(twelve_index(ming.index() as i32 - role.index() as i32))
     }
@@ -230,7 +234,7 @@ impl Ziwei {
     }
 
     /// 层四化 overlay：本命为 `None`；大限/流年为该层干四化。
-    pub fn overlay_transformations(self, view: ZiweiView) -> Option<[LayerTransformation; 4]> {
+    pub fn overlay_transformations(&self, view: ZiweiView) -> Option<[LayerTransformation; 4]> {
         match view {
             ZiweiView::Natal => None,
             ZiweiView::Decade(index) => {
@@ -261,7 +265,7 @@ impl Ziwei {
     }
 
     /// 当前视图下「命」所在地支。
-    fn view_ming_branch(self, view: ZiweiView) -> Branch {
+    fn view_ming_branch(&self, view: ZiweiView) -> Branch {
         match view {
             ZiweiView::Natal => self.ming_branch,
             ZiweiView::Decade(index) => self.decade_step(index).ming_branch,

--- a/docs/guides/ziwei-core-reference.html
+++ b/docs/guides/ziwei-core-reference.html
@@ -367,7 +367,7 @@
         <div class="card">
           <h4>设计原则</h4>
           <ul>
-            <li><strong>一份本命真相源</strong>：<code class="inline">Ziwei</code>（Copy，构造期算完）</li>
+            <li><strong>一份本命真相源</strong>：<code class="inline">Ziwei</code>（体积较大，仅 Clone；查询 <code class="inline">&amp;self</code>，构造期算完）</li>
             <li><strong>视图只叠层</strong>：不重算星/宫干/飞边/生年四化</li>
             <li><strong>禁止结果注入</strong>：测例不能预填命宫/紫微</li>
             <li><strong>坐标分流</strong>：对内寅环，对外 <code class="inline">Branch</code>（子=0）</li>


### PR DESCRIPTION
## 变更内容

- 从 320 字节的 `Ziwei` 命盘类型上移除 `Copy`，保留显式 `Clone`
- 将所有不消耗命盘所有权的查询方法从 `self` 改为 `&self`
- 更新公开指南，说明借用式查询和显式克隆语义

## 原因

`Ziwei` 包含十二宫、十八颗星曜的位置、48 条飞化边以及十二步大限。实测大小为 320 字节，因此隐式复制会把一笔不可忽略的成本隐藏在普通查询调用之后。

## 影响

`chart.bureau()` 等常规调用方式保持不变。确实需要另一份命盘值时，原先依赖隐式 `Copy` 的代码现在必须显式调用 `chart.clone()`。

## 验证

- 实测 `std::mem::size_of::<Ziwei>() == 320`
- `cargo fmt --all -- --check`
- `cargo test --workspace --locked`
- `cargo test --workspace --locked --release`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `git diff --check`

严格 rustdoc 警告由 #274 独立修复。