### PR TITLE
refactor: name star galaxies explicitly

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -13,6 +13,7 @@
 | `PalaceName` | 十二宫名；枚举成员沿用原十二宫职顺序 |
 | `Palace` | 一个宫位的宫名、地支、天干、星曜与四条宫位四化关系 |
 | `StarKey` | 十八颗首批星曜的稳定身份 |
+| `StarGalaxy` | 星曜所属斗系；`South`、`North`、`Central` 分别表示南斗、北斗、中斗 |
 | `Star` | 星曜在本命盘中的落位事实，包含生年四化与自化 |
 | `Transformation` | 四化稳定代码 `A / B / C / D`；展示层可映射为禄、权、科、忌 |
 | `PalaceTransformation` | 一条从源宫到目标星曜所在宫的四化关系 |

--- a/crates/ziwei_core/src/star.rs
+++ b/crates/ziwei_core/src/star.rs
@@ -58,11 +58,11 @@ pub enum StarType {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum StarGalaxy {
     /// 南斗。
-    S,
+    South,
     /// 北斗。
-    N,
+    North,
     /// 中斗。
-    C,
+    Central,
 }
 
 impl StarKey {
@@ -124,13 +124,13 @@ impl StarKey {
     pub const fn galaxy(self) -> Option<StarGalaxy> {
         match self {
             Self::ZiWei | Self::ZuoFu | Self::YouBi | Self::WenChang | Self::WenQu => {
-                Some(StarGalaxy::C)
+                Some(StarGalaxy::Central)
             }
             Self::TianJi | Self::TaiYang | Self::WuQu | Self::TianTong | Self::LianZhen => {
-                Some(StarGalaxy::N)
+                Some(StarGalaxy::North)
             }
             Self::TaiYin | Self::TanLang | Self::JuMen | Self::TianLiang | Self::PoJun => {
-                Some(StarGalaxy::S)
+                Some(StarGalaxy::South)
             }
             Self::TianFu | Self::TianXiang | Self::QiSha => None,
         }
@@ -234,9 +234,9 @@ mod tests {
     fn star_keys_have_stable_identity_metadata() {
         assert_eq!(StarKey::ALL.len(), 18);
         assert_eq!(StarKey::ZiWei.as_str(), "zi_wei");
-        assert_eq!(StarKey::PoJun.galaxy(), Some(StarGalaxy::S));
-        assert_eq!(StarKey::TianJi.galaxy(), Some(StarGalaxy::N));
-        assert_eq!(StarKey::WenQu.galaxy(), Some(StarGalaxy::C));
+        assert_eq!(StarKey::PoJun.galaxy(), Some(StarGalaxy::South));
+        assert_eq!(StarKey::TianJi.galaxy(), Some(StarGalaxy::North));
+        assert_eq!(StarKey::WenQu.galaxy(), Some(StarGalaxy::Central));
         assert_eq!(StarKey::TianFu.galaxy(), None);
         assert_eq!(StarKey::ZuoFu.star_type(), StarType::Minor);
         assert_eq!(StarKey::QiSha.star_type(), StarType::Major);

--- a/docs/design/ziwei-model.md
+++ b/docs/design/ziwei-model.md
@@ -81,7 +81,7 @@ QianYi, JiaoYou, GuanLu, TianZhai, FuDe, FuMu
 `StarKey` 只承载稳定身份及领域分类：
 
 - `StarType`: `Major / Minor / Auxiliary`；十四主星为 `Major`，左辅、右弼、文昌、文曲为 `Minor`，首批没有 `Auxiliary` 成员。
-- `StarGalaxy`: `S / N / C`，分别表示南斗、北斗、中斗；没有斗系的星返回 `None`。
+- `StarGalaxy`: `South / North / Central`，分别表示南斗、北斗、中斗；没有斗系的星返回 `None`。
 - `as_str()` 返回稳定 snake_case key，不提供简繁体显示文案。
 
 `StarKey::ALL` 沿用当前十八星算法顺序，不参与决定安星先后；安星结果由计算规则决定，数组只提供稳定遍历顺序。


### PR DESCRIPTION
## 变更

- 将 `StarGalaxy` 枚举成员从 `S / N / C` 改为 `South / North / Central`
- 同步星曜映射测试、领域词汇表与模型文档

## 原因

单字母缩写不能直接表达南斗、北斗、中斗的领域含义；完整名称更适合作为稳定公开类型成员。

## 影响

这是公开枚举成员的直接重命名，不保留旧成员兼容层。

## 验证

- `cargo test --workspace`：40 项通过
- `cargo clippy --workspace --all-targets -- -D warnings`：通过
- `git diff --check`：通过