### PR TITLE
test: cover five tiger escape invariants

### DIFF
--- a/crates/ziwei_core/src/placement.rs
+++ b/crates/ziwei_core/src/placement.rs
@@ -172,6 +172,128 @@ mod tests {
     use super::*;
 
     #[test]
+    fn palace_stems_follow_five_tiger_escape_for_every_year_stem_and_branch() {
+        let branches_from_yin_to_chou = [
+            Branch::Yin,
+            Branch::Mao,
+            Branch::Chen,
+            Branch::Si,
+            Branch::Wu,
+            Branch::Wei,
+            Branch::Shen,
+            Branch::You,
+            Branch::Xu,
+            Branch::Hai,
+            Branch::Zi,
+            Branch::Chou,
+        ];
+        let cases = [
+            (
+                [Stem::Jia, Stem::Ji],
+                [
+                    Stem::Bing,
+                    Stem::Ding,
+                    Stem::Wu,
+                    Stem::Ji,
+                    Stem::Geng,
+                    Stem::Xin,
+                    Stem::Ren,
+                    Stem::Gui,
+                    Stem::Jia,
+                    Stem::Yi,
+                    Stem::Bing,
+                    Stem::Ding,
+                ],
+            ),
+            (
+                [Stem::Yi, Stem::Geng],
+                [
+                    Stem::Wu,
+                    Stem::Ji,
+                    Stem::Geng,
+                    Stem::Xin,
+                    Stem::Ren,
+                    Stem::Gui,
+                    Stem::Jia,
+                    Stem::Yi,
+                    Stem::Bing,
+                    Stem::Ding,
+                    Stem::Wu,
+                    Stem::Ji,
+                ],
+            ),
+            (
+                [Stem::Bing, Stem::Xin],
+                [
+                    Stem::Geng,
+                    Stem::Xin,
+                    Stem::Ren,
+                    Stem::Gui,
+                    Stem::Jia,
+                    Stem::Yi,
+                    Stem::Bing,
+                    Stem::Ding,
+                    Stem::Wu,
+                    Stem::Ji,
+                    Stem::Geng,
+                    Stem::Xin,
+                ],
+            ),
+            (
+                [Stem::Ding, Stem::Ren],
+                [
+                    Stem::Ren,
+                    Stem::Gui,
+                    Stem::Jia,
+                    Stem::Yi,
+                    Stem::Bing,
+                    Stem::Ding,
+                    Stem::Wu,
+                    Stem::Ji,
+                    Stem::Geng,
+                    Stem::Xin,
+                    Stem::Ren,
+                    Stem::Gui,
+                ],
+            ),
+            (
+                [Stem::Wu, Stem::Gui],
+                [
+                    Stem::Jia,
+                    Stem::Yi,
+                    Stem::Bing,
+                    Stem::Ding,
+                    Stem::Wu,
+                    Stem::Ji,
+                    Stem::Geng,
+                    Stem::Xin,
+                    Stem::Ren,
+                    Stem::Gui,
+                    Stem::Jia,
+                    Stem::Yi,
+                ],
+            ),
+        ];
+
+        for (birth_stems, expected_from_yin_to_chou) in cases {
+            for birth_stem in birth_stems {
+                let actual_by_branch = compute_palace_stems(birth_stem);
+
+                for (branch, expected_stem) in branches_from_yin_to_chou
+                    .into_iter()
+                    .zip(expected_from_yin_to_chou)
+                {
+                    assert_eq!(
+                        actual_by_branch[branch.index()],
+                        expected_stem,
+                        "birth_stem={birth_stem:?} branch={branch:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
     fn tianfu_mirrors_ziwei_for_every_supported_day_and_bureau() {
         for day in 1..=30u8 {
             for bureau_number in [2u8, 3, 4, 5, 6] {

--- a/docs/research/five-tiger-escape-algorithm.md
+++ b/docs/research/five-tiger-escape-algorithm.md
@@ -117,14 +117,11 @@ stem = (寅宫起干下标 + 寅环下标) mod 10
 `Star::origin_transformation` 可直接由生年天干查四化表。由于上述宫干相等不变量，同一组
 四化也出现在 `origin_palace` 的 `PalaceTransformation` 中。
 
-## 5. 测试缺口
+## 5. 测试覆盖
 
-当前 `placement.rs` 测试间接调用 `compute_palace_stems`，但没有直接断言五组寅宫起干，
-也没有穷举十二支顺布结果。建议后续增加一条表驱动测试，锁定：
+`placement.rs` 的表驱动测试
+`palace_stems_follow_five_tiger_escape_for_every_year_stem_and_branch` 现已锁定：
 
 1. 五组年干共享各自的寅宫起干；
 2. 每组从寅至丑逐宫前进一干；
 3. 返回数组仍按 `Branch::index()` 的子序索引。
-
-在补充该测试前，本结论来自原典对照与当前源码逐项推演；现有测试通过不是这条不变量的
-独立证明。


### PR DESCRIPTION
## 变更

- 为 `compute_palace_stems` 增加五虎遁表驱动测试
- 覆盖五组生年干、寅至丑逐宫顺布，以及 `Branch::index()` 子序索引
- 更新研究文档，将原测试缺口标记为已覆盖

## 原因

现有测试只间接调用五虎遁算法，没有独立锁定研究文档确认的三条核心不变量。

## 影响

仅增加测试与同步文档，不修改运行时代码或公开 API。

## 验证

- `cargo fmt --all --check`
- `cargo test -p ziwei_core`（38 passed）
- `cargo clippy -p ziwei_core --all-targets -- -D warnings`