### PR TITLE
refactor: rename body identifiers to shen

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -6,8 +6,8 @@
 
 | 术语 | 含义 |
 | --- | --- |
-| `ZiweiBirth` | 历法层归一化后的公开农历出生资料；`year` 是农历年序号，可计算各大限的农历年份与虚岁 |
-| `ZiweiInput` | 不含绝对农历年序号的公开输入；只计算虚岁 |
+| `ZiweiBirth` | 紫微斗数领域中由历法层归一化后的公开农历出生资料；`year` 是农历年序号，可计算各大限的农历年份与虚岁 |
+| `ZiweiInput` | 紫微斗数领域中不含绝对农历年序号的公开输入；只计算虚岁 |
 | `Gender` | 命主的阴阳性别；`Yang` 表示阳男，`Yin` 表示阴女，领域值不使用 `Male` / `Female` |
 | `NatalContext` | 两种输入归一化后的私有只读上下文，不是第三种公开输入 |
 | `Natal` | `ziwei_core` 产出的不可变本命盘 |
@@ -50,7 +50,7 @@
 - 十二宫名各出现一次；十八个 `StarKey` 各出现一次。
 - 每宫恰有四条 `PalaceTransformation`，顺序固定为 `A / B / C / D`。
 - 全盘恰有四颗星的 `origin_transformation` 为 `Some(A/B/C/D)`，每类一次。
-- `ming_palace`、`body_palace`、`origin_palace` 的宫名与地支必须能解析到同一个 `Palace`。
+- `ming_palace`、`shen_palace`、`origin_palace` 的宫名与地支必须能解析到同一个 `Palace`。
 - `origin_palace` 所在宫位的天干必须与生年天干一致。
 - 十二个大限按 `DecadeIndex(0..=11)` 排列，每个大限恰有十个连续虚岁条目；同一张盘的 `year` 必须全部为 `Some` 或全部为 `None`。
 

--- a/crates/ziwei_core/src/natal.rs
+++ b/crates/ziwei_core/src/natal.rs
@@ -90,8 +90,8 @@ pub struct Natal {
     palaces: [Palace; 12],
     ming_palace: PalaceName,
     ming_palace_branch: Branch,
-    body_palace: PalaceName,
-    body_palace_branch: Branch,
+    shen_palace: PalaceName,
+    shen_palace_branch: Branch,
     origin_palace: PalaceName,
     origin_palace_branch: Branch,
     bureau: FiveElementBureau,
@@ -120,8 +120,8 @@ impl Natal {
         palaces: [Palace; 12],
         ming_palace: PalaceName,
         ming_palace_branch: Branch,
-        body_palace: PalaceName,
-        body_palace_branch: Branch,
+        shen_palace: PalaceName,
+        shen_palace_branch: Branch,
         origin_palace: PalaceName,
         origin_palace_branch: Branch,
         bureau: FiveElementBureau,
@@ -134,8 +134,8 @@ impl Natal {
             palaces,
             ming_palace,
             ming_palace_branch,
-            body_palace,
-            body_palace_branch,
+            shen_palace,
+            shen_palace_branch,
             origin_palace,
             origin_palace_branch,
             bureau,
@@ -170,13 +170,13 @@ impl Natal {
     }
 
     /// 身宫叠落的宫名。
-    pub const fn body_palace(&self) -> PalaceName {
-        self.body_palace
+    pub const fn shen_palace(&self) -> PalaceName {
+        self.shen_palace
     }
 
     /// 身宫地支。
-    pub const fn body_palace_branch(&self) -> Branch {
-        self.body_palace_branch
+    pub const fn shen_palace_branch(&self) -> Branch {
+        self.shen_palace_branch
     }
 
     /// 来因宫叠落的宫名。
@@ -306,13 +306,13 @@ mod tests {
         let natal = Natal::from_birth(sample_birth());
         let coordinates = [
             (natal.ming_palace(), natal.ming_palace_branch()),
-            (natal.body_palace(), natal.body_palace_branch()),
+            (natal.shen_palace(), natal.shen_palace_branch()),
             (natal.origin_palace(), natal.origin_palace_branch()),
         ];
 
         assert_eq!(natal.ming_palace(), PalaceName::Ming);
         assert_eq!(natal.ming_palace_branch(), Branch::Zi);
-        assert_eq!(natal.body_palace_branch(), Branch::Shen);
+        assert_eq!(natal.shen_palace_branch(), Branch::Shen);
         for (name, branch) in coordinates {
             assert_eq!(
                 natal
@@ -354,10 +354,10 @@ mod tests {
             ),
         ];
 
-        for (input, ming, body, bureau, ziwei) in cases {
+        for (input, ming, shen, bureau, ziwei) in cases {
             let natal = Natal::from_input(input);
             assert_eq!(natal.ming_palace_branch(), ming);
-            assert_eq!(natal.body_palace_branch(), body);
+            assert_eq!(natal.shen_palace_branch(), shen);
             assert_eq!(natal.bureau(), bureau);
             assert_eq!(find_star(&natal, StarKey::ZiWei).0.branch(), ziwei);
         }

--- a/crates/ziwei_core/src/pipeline.rs
+++ b/crates/ziwei_core/src/pipeline.rs
@@ -6,7 +6,7 @@ use super::{
     natal::{Natal, NatalContext},
     palace::{Palace, PalaceName, PalaceTransformation},
     placement::{
-        PalaceSeed, build_palace_seeds, bureau_from_ming_stems, compute_ming_body,
+        PalaceSeed, build_palace_seeds, bureau_from_ming_stems, compute_ming_shen_branches,
         compute_palace_stems, merge_assistants, place_assistants, place_major_stars,
     },
     position::branch_from_yin0,
@@ -18,10 +18,10 @@ use super::{
 
 /// 由归一化上下文计算完整本命盘。
 pub(crate) fn build_natal(context: NatalContext) -> Natal {
-    let ming_body = compute_ming_body(context.month(), context.hour());
+    let ming_shen_branches = compute_ming_shen_branches(context.month(), context.hour());
     let palace_stems = compute_palace_stems(context.birth_stem());
-    let bureau = bureau_from_ming_stems(ming_body.ming, &palace_stems);
-    let palace_seeds = build_palace_seeds(ming_body.ming, &palace_stems);
+    let bureau = bureau_from_ming_stems(ming_shen_branches.ming, &palace_stems);
+    let palace_seeds = build_palace_seeds(ming_shen_branches.ming, &palace_stems);
     let star_branches = merge_assistants(
         place_major_stars(context.day(), bureau.number()),
         place_assistants(context.month(), context.hour()),
@@ -54,14 +54,14 @@ pub(crate) fn build_natal(context: NatalContext) -> Natal {
     });
 
     let origin_palace_branch = context.birth_stem().origin_palace_branch();
-    let ming_palace = palace_name_at(ming_body.ming, &palace_seeds);
-    let body_palace = palace_name_at(ming_body.body, &palace_seeds);
+    let ming_palace = palace_name_at(ming_shen_branches.ming, &palace_seeds);
+    let shen_palace = palace_name_at(ming_shen_branches.shen, &palace_seeds);
     let origin_palace = palace_name_at(origin_palace_branch, &palace_seeds);
     let (decade_direction, decades) = build_decades(
         context.gender(),
         context.birth_stem(),
         context.year(),
-        ming_body.ming,
+        ming_shen_branches.ming,
         bureau.number(),
     );
 
@@ -70,9 +70,9 @@ pub(crate) fn build_natal(context: NatalContext) -> Natal {
         Zodiac::from_branch(context.birth_branch()),
         palaces,
         ming_palace,
-        ming_body.ming,
-        body_palace,
-        ming_body.body,
+        ming_shen_branches.ming,
+        shen_palace,
+        ming_shen_branches.shen,
         origin_palace,
         origin_palace_branch,
         bureau,

--- a/crates/ziwei_core/src/placement.rs
+++ b/crates/ziwei_core/src/placement.rs
@@ -11,9 +11,9 @@ use super::{
 
 /// 命宫与身宫地支。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct MingBody {
+pub(crate) struct MingShenBranches {
     pub(crate) ming: Branch,
-    pub(crate) body: Branch,
+    pub(crate) shen: Branch,
 }
 
 /// 尚未附加星曜与四化关系的宫位坐标。
@@ -34,12 +34,12 @@ pub(crate) struct AssistantStars {
 }
 
 /// 寅起正月；命宫逆时、身宫顺时。
-pub(crate) fn compute_ming_body(month: u8, hour: u8) -> MingBody {
+pub(crate) fn compute_ming_shen_branches(month: u8, hour: u8) -> MingShenBranches {
     let ming_yin0 = twelve_index(i32::from(month) - i32::from(hour));
-    let body_yin0 = twelve_index(i32::from(month) + i32::from(hour));
-    MingBody {
+    let shen_yin0 = twelve_index(i32::from(month) + i32::from(hour));
+    MingShenBranches {
         ming: branch_from_yin0(ming_yin0),
-        body: branch_from_yin0(body_yin0),
+        shen: branch_from_yin0(shen_yin0),
     }
 }
 
@@ -332,18 +332,18 @@ mod tests {
     }
 
     #[test]
-    fn ming_body_and_assistants_follow_all_month_hour_formulas() {
+    fn ming_shen_branches_and_assistants_follow_all_month_hour_formulas() {
         for month in 0..12u8 {
             for hour in 0..12u8 {
-                let ming_body = compute_ming_body(month, hour);
+                let ming_shen_branches = compute_ming_shen_branches(month, hour);
                 let assistants = place_assistants(month, hour);
 
                 assert_eq!(
-                    ming_body.ming,
+                    ming_shen_branches.ming,
                     branch_from_yin0(twelve_index(i32::from(month) - i32::from(hour)))
                 );
                 assert_eq!(
-                    ming_body.body,
+                    ming_shen_branches.shen,
                     branch_from_yin0(twelve_index(i32::from(month) + i32::from(hour)))
                 );
                 assert_eq!(

--- a/docs/design/domain-semantics-convergence.md
+++ b/docs/design/domain-semantics-convergence.md
@@ -18,7 +18,7 @@
 
 ```text
 ming_palace / ming_palace_branch
-body_palace / body_palace_branch
+shen_palace / shen_palace_branch
 origin_palace / origin_palace_branch
 ```
 

--- a/docs/design/ziwei-model.md
+++ b/docs/design/ziwei-model.md
@@ -12,8 +12,8 @@ pub struct Natal {
 
     ming_palace: PalaceName,
     ming_palace_branch: Branch,
-    body_palace: PalaceName,
-    body_palace_branch: Branch,
+    shen_palace: PalaceName,
+    shen_palace_branch: Branch,
     origin_palace: PalaceName,
     origin_palace_branch: Branch,
 

--- a/docs/guides/ziwei-core-reference.html
+++ b/docs/guides/ziwei-core-reference.html
@@ -1098,7 +1098,7 @@
 │  ├─ stars: Vec&lt;<span class="type">Star</span>&gt;
 │  └─ transformations: [<span class="type">PalaceTransformation</span>; 4]
 ├─ <span class="accent">ming_palace</span> + ming_palace_branch
-├─ <span class="accent">body_palace</span> + body_palace_branch
+├─ <span class="accent">shen_palace</span> + shen_palace_branch
 ├─ <span class="accent">origin_palace</span> + origin_palace_branch
 ├─ bureau: <span class="type">FiveElementBureau</span>
 ├─ decade_direction: <span class="type">DecadeDirection</span>
@@ -1310,7 +1310,7 @@ QiSha, PoJun, ZuoFu, YouBi, WenChang, WenQu</code></pre>
                   <tr><td>ZiweiInput</td><td>try_new(gender, stem, branch, month, day, hour)</td><td>含年干支、不含年份的验证输入</td></tr>
                   <tr><td>Natal</td><td>from_birth / from_input</td><td>两条无失败构造入口</td></tr>
                   <tr><td>Natal</td><td>context / zodiac / palaces / decades</td><td>上下文与主要聚合</td></tr>
-                  <tr><td>Natal</td><td>ming_palace(_branch) / body_palace(_branch) / origin_palace(_branch)</td><td>三组宫名 + 地支坐标</td></tr>
+                  <tr><td>Natal</td><td>ming_palace(_branch) / shen_palace(_branch) / origin_palace(_branch)</td><td>三组宫名 + 地支坐标</td></tr>
                   <tr><td>Natal</td><td>bureau / decade_direction</td><td>五行局与大限方向</td></tr>
                   <tr><td>Palace</td><td>name / branch / stem / stars / transformations</td><td>完整宫位事实</td></tr>
                   <tr><td>PalaceTransformation</td><td>source_name / source_branch / transformation / target_name / target_branch / star_key</td><td>完整四化关系边</td></tr>


### PR DESCRIPTION
## 变更

- 将私有类型 `MingBody` 重命名为 `MingShenBranches`
- 将表示身宫的 `Body/body` 标识统一为 `Shen/shen`
- 将公开 API `body_palace()` / `body_palace_branch()` 重命名为 `shen_palace()` / `shen_palace_branch()`
- 同步计算流水线、测试、领域词汇表、模型文档和参考文档
- 保留 `ZiweiBirth`、`ZiweiInput`、`ZiweiInputError`，以明确它们是紫微斗数领域类型

## 原因

命宫使用拼音 `Ming`，身宫却混用英文 `Body`，导致同一组紫微领域概念的命名边界不一致。统一采用 `Ming / Shen` 后，领域术语与天干、地支、星曜、宫名的拼音策略一致。

## 影响

这是公开 API 的破坏性重命名，不保留旧的 `body_palace` 兼容别名。调用方需要改用 `shen_palace` 与 `shen_palace_branch`。

## 验证

- `cargo fmt --all -- --check`：通过
- `cargo test --workspace`：41 项通过
- `cargo clippy --workspace --all-targets -- -D warnings`：通过
- `cargo doc --workspace --no-deps`：通过
- `git diff --check`：通过