### PR TITLE
统一 ziwei_core 内部命名

### DIFF
--- a/crates/ziwei_core/src/input.rs
+++ b/crates/ziwei_core/src/input.rs
@@ -265,13 +265,13 @@ const fn validate_birth_year(year: i32) -> Result<(), ZiweiInputError> {
 
 /// 校验月 ∈ 0..=11、日 ∈ 1..=30、时 ∈ 0..=11。
 pub(crate) fn validate_month_day_hour(month: u8, day: u8, hour: u8) -> Result<(), ZiweiInputError> {
-    if !ring_position_is_valid(month) {
+    if !is_valid_ring_position(month) {
         return Err(ZiweiInputError::MonthOutOfRange { value: month });
     }
     if !(1..=30).contains(&day) {
         return Err(ZiweiInputError::DayOutOfRange { value: day });
     }
-    if !ring_position_is_valid(hour) {
+    if !is_valid_ring_position(hour) {
         return Err(ZiweiInputError::HourOutOfRange { value: hour });
     }
     Ok(())
@@ -287,7 +287,7 @@ pub(crate) fn validate_year_pillar(stem: Stem, branch: Branch) -> Result<(), Ziw
 }
 
 /// `position` 已是规范的 0..=11 环下标时为真（与 `twelve_index` 往返一致）。
-const fn ring_position_is_valid(position: u8) -> bool {
+const fn is_valid_ring_position(position: u8) -> bool {
     twelve_index(position as i32) == position
 }
 

--- a/crates/ziwei_core/src/natal.rs
+++ b/crates/ziwei_core/src/natal.rs
@@ -354,12 +354,12 @@ mod tests {
             ),
         ];
 
-        for (input, ming, shen, bureau, ziwei) in cases {
+        for (input, ming, shen, bureau, zi_wei_branch) in cases {
             let natal = Natal::from_input(input);
             assert_eq!(natal.ming_palace_branch(), ming);
             assert_eq!(natal.shen_palace_branch(), shen);
             assert_eq!(natal.bureau(), bureau);
-            assert_eq!(find_star(&natal, StarKey::ZiWei).0.branch(), ziwei);
+            assert_eq!(find_star(&natal, StarKey::ZiWei).0.branch(), zi_wei_branch);
         }
 
         let first = Natal::from_input(cases[0].0);

--- a/crates/ziwei_core/src/pipeline.rs
+++ b/crates/ziwei_core/src/pipeline.rs
@@ -6,7 +6,7 @@ use super::{
     natal::{Natal, NatalContext},
     palace::{Palace, PalaceName, PalaceTransformation},
     placement::{
-        PalaceSeed, build_palace_seeds, bureau_from_ming_stems, compute_ming_shen_branches,
+        PalaceSeed, build_palace_seeds, bureau_from_ming_palace, compute_ming_shen_branches,
         compute_palace_stems, merge_assistants, place_assistants, place_major_stars,
     },
     position::branch_from_yin0,
@@ -20,7 +20,7 @@ use super::{
 pub(crate) fn build_natal(context: NatalContext) -> Natal {
     let ming_shen_branches = compute_ming_shen_branches(context.month(), context.hour());
     let palace_stems = compute_palace_stems(context.birth_stem());
-    let bureau = bureau_from_ming_stems(ming_shen_branches.ming, &palace_stems);
+    let bureau = bureau_from_ming_palace(ming_shen_branches.ming, &palace_stems);
     let palace_seeds = build_palace_seeds(ming_shen_branches.ming, &palace_stems);
     let star_branches = merge_assistants(
         place_major_stars(context.day(), bureau.number()),
@@ -30,8 +30,8 @@ pub(crate) fn build_natal(context: NatalContext) -> Natal {
     let mut stars_by_branch: [Vec<Star>; 12] = std::array::from_fn(|_| Vec::new());
     for key in StarKey::ALL {
         let branch = star_branches[key.index()];
-        let origin_transformation = origin_transformation(context.birth_stem(), key);
-        let self_transformations = self_transformations(key, branch, &palace_seeds);
+        let origin_transformation = find_origin_transformation(context.birth_stem(), key);
+        let self_transformations = compute_self_transformations(key, branch, &palace_seeds);
         stars_by_branch[branch.index()].push(Star::new(
             key,
             origin_transformation,
@@ -85,13 +85,13 @@ fn palace_name_at(branch: Branch, palace_seeds: &[PalaceSeed; 12]) -> PalaceName
     palace_seeds[branch.index()].name
 }
 
-fn origin_transformation(birth_stem: Stem, key: StarKey) -> Option<Transformation> {
+fn find_origin_transformation(birth_stem: Stem, key: StarKey) -> Option<Transformation> {
     Transformation::ALL
         .into_iter()
         .find(|transformation| birth_stem.transformation_star(*transformation) == key)
 }
 
-fn self_transformations(
+fn compute_self_transformations(
     key: StarKey,
     target_branch: Branch,
     palace_seeds: &[PalaceSeed; 12],

--- a/crates/ziwei_core/src/placement.rs
+++ b/crates/ziwei_core/src/placement.rs
@@ -54,7 +54,7 @@ pub(crate) fn compute_palace_stems(birth_stem: Stem) -> [Stem; 12] {
 }
 
 /// 命宫干支确定五行局。
-pub(crate) fn bureau_from_ming_stems(
+pub(crate) fn bureau_from_ming_palace(
     ming_palace_branch: Branch,
     palace_stems: &[Stem; 12],
 ) -> FiveElementBureau {
@@ -113,8 +113,8 @@ pub(crate) fn place_major_stars(day: u8, bureau_number: u8) -> [Branch; 18] {
         value if value % 2 == 1 => -value,
         value => value,
     };
-    let ziwei_yin0 = twelve_index((quotient - 1) + correction);
-    let tianfu_yin0 = twelve_index(-i32::from(ziwei_yin0));
+    let zi_wei_yin0 = twelve_index((quotient - 1) + correction);
+    let tian_fu_yin0 = twelve_index(-i32::from(zi_wei_yin0));
 
     let mut branches = [Branch::Zi; 18];
     for (key, offset) in [
@@ -128,7 +128,7 @@ pub(crate) fn place_major_stars(day: u8, bureau_number: u8) -> [Branch; 18] {
         set_star_at_yin0(
             &mut branches,
             key,
-            twelve_index(i32::from(ziwei_yin0) - offset),
+            twelve_index(i32::from(zi_wei_yin0) - offset),
         );
     }
     for (key, offset) in [
@@ -144,7 +144,7 @@ pub(crate) fn place_major_stars(day: u8, bureau_number: u8) -> [Branch; 18] {
         set_star_at_yin0(
             &mut branches,
             key,
-            twelve_index(i32::from(tianfu_yin0) + offset),
+            twelve_index(i32::from(tian_fu_yin0) + offset),
         );
     }
 
@@ -294,21 +294,21 @@ mod tests {
     }
 
     #[test]
-    fn tianfu_mirrors_ziwei_for_every_supported_day_and_bureau() {
+    fn tian_fu_mirrors_zi_wei_for_every_supported_day_and_bureau() {
         for day in 1..=30u8 {
             for bureau_number in [2u8, 3, 4, 5, 6] {
                 let stars = place_major_stars(day, bureau_number);
-                let ziwei = branch_index_to_yin0(
+                let zi_wei_yin0 = branch_index_to_yin0(
                     u8::try_from(stars[StarKey::ZiWei.index()].index())
                         .expect("branch index fits in u8"),
                 );
-                let tianfu = branch_index_to_yin0(
+                let tian_fu_yin0 = branch_index_to_yin0(
                     u8::try_from(stars[StarKey::TianFu.index()].index())
                         .expect("branch index fits in u8"),
                 );
                 assert_eq!(
-                    tianfu,
-                    twelve_index(-i32::from(ziwei)),
+                    tian_fu_yin0,
+                    twelve_index(-i32::from(zi_wei_yin0)),
                     "day={day} bureau={bureau_number}"
                 );
             }


### PR DESCRIPTION
## 变更

- 将环位置校验函数改为标准布尔谓词命名
- 让五行局 helper 准确表达命宫语义
- 区分四化查找/计算 helper 与只读 getter
- 统一紫微星、天府星内部标识的单词边界

## 原因

内部函数和局部标识存在谓词顺序、语义范围及领域词边界不一致的问题，增加了代码阅读和搜索成本。

## 影响

仅重命名 crate 内部函数、局部变量和测试，不改变公开 API 或运行行为。

## 验证

- `cargo fmt --all -- --check`
- `cargo test --workspace --locked`（41 项通过）
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `git diff --check`