### PR TITLE
perf(core): optimize natal chart construction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,461 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "allocation-counter"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beb9e990c0a33699f1984d85a6abead615ccc72dd8130bf3e15dcabe2ca149c9"
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "syn"
+version = "2.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "ziwei"
 version = "0.1.0"
 dependencies = [
@@ -20,7 +475,18 @@ version = "0.1.0"
 [[package]]
 name = "ziwei_core"
 version = "0.1.0"
+dependencies = [
+ "allocation-counter",
+ "arrayvec",
+ "criterion",
+]
 
 [[package]]
 name = "ziwei_query"
 version = "0.1.0"
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ readme = "README.md"
 repository = "https://github.com/matharts/ziwei"
 
 [workspace.dependencies]
+allocation-counter = "0.8.1"
+arrayvec = "0.7.8"
+criterion = { version = "0.8.2", default-features = false, features = ["cargo_bench_support"] }
 ziwei = { path = "crates/ziwei" }
 ziwei_analysis = { path = "crates/ziwei_analysis" }
 ziwei_calendar = { path = "crates/ziwei_calendar" }

--- a/crates/ziwei/tests/natal_exhaustive.rs
+++ b/crates/ziwei/tests/natal_exhaustive.rs
@@ -1,0 +1,177 @@
+//! Exhaustive public-contract baseline for `Natal` construction.
+
+use ziwei::{Branch, Gender, Natal, Palace, StarKey, Stem, Transformation, ZiweiInput};
+
+const BRANCHES: [Branch; 12] = [
+    Branch::Zi,
+    Branch::Chou,
+    Branch::Yin,
+    Branch::Mao,
+    Branch::Chen,
+    Branch::Si,
+    Branch::Wu,
+    Branch::Wei,
+    Branch::Shen,
+    Branch::You,
+    Branch::Xu,
+    Branch::Hai,
+];
+
+const PALACE_ORDER: [Branch; 12] = [
+    Branch::Yin,
+    Branch::Mao,
+    Branch::Chen,
+    Branch::Si,
+    Branch::Wu,
+    Branch::Wei,
+    Branch::Shen,
+    Branch::You,
+    Branch::Xu,
+    Branch::Hai,
+    Branch::Zi,
+    Branch::Chou,
+];
+
+const STEMS: [Stem; 10] = [
+    Stem::Jia,
+    Stem::Yi,
+    Stem::Bing,
+    Stem::Ding,
+    Stem::Wu,
+    Stem::Ji,
+    Stem::Geng,
+    Stem::Xin,
+    Stem::Ren,
+    Stem::Gui,
+];
+
+fn palace_at_branch(natal: &Natal, branch: Branch) -> &Palace {
+    &natal.palaces()[(branch.index() + 10) % 12]
+}
+
+fn opposite(branch: Branch) -> Branch {
+    BRANCHES[(branch.index() + 6) % 12]
+}
+
+fn star_index(key: StarKey) -> usize {
+    StarKey::ALL
+        .iter()
+        .position(|candidate| *candidate == key)
+        .expect("StarKey::ALL contains every published star identity")
+}
+
+fn expected_transformation_from(
+    natal: &Natal,
+    source: Branch,
+    key: StarKey,
+) -> Option<Transformation> {
+    palace_at_branch(natal, source)
+        .transformations()
+        .iter()
+        .find(|relation| relation.star_key() == key)
+        .map(|relation| relation.transformation())
+}
+
+fn assert_natal_graph_invariants(natal: &Natal, birth_stem: Stem) {
+    for (palace, expected_branch) in natal.palaces().iter().zip(PALACE_ORDER) {
+        assert_eq!(palace.branch(), expected_branch);
+        assert!(
+            palace.stars().len() <= 6,
+            "single-palace star capacity exceeded: branch={:?}, count={}",
+            palace.branch(),
+            palace.stars().len(),
+        );
+    }
+
+    let mut star_branches = [None; 18];
+    for palace in natal.palaces() {
+        for star in palace.stars() {
+            let previous = star_branches[star_index(star.key())].replace(palace.branch());
+            assert_eq!(
+                previous,
+                None,
+                "star appears more than once: {:?}",
+                star.key()
+            );
+        }
+    }
+    assert!(
+        star_branches.iter().all(Option::is_some),
+        "every StarKey appears exactly once",
+    );
+
+    for palace in natal.palaces() {
+        for (relation, expected_transformation) in
+            palace.transformations().iter().zip(Transformation::ALL)
+        {
+            assert_eq!(relation.source_name(), palace.name());
+            assert_eq!(relation.source_branch(), palace.branch());
+            assert_eq!(relation.transformation(), expected_transformation);
+
+            let target_branch = star_branches[star_index(relation.star_key())]
+                .expect("every transformation target star has a placement");
+            assert_eq!(relation.target_branch(), target_branch);
+            assert_eq!(
+                relation.target_name(),
+                palace_at_branch(natal, target_branch).name(),
+            );
+        }
+    }
+
+    for (name, branch) in [
+        (natal.ming_palace(), natal.ming_palace_branch()),
+        (natal.shen_palace(), natal.shen_palace_branch()),
+        (natal.origin_palace(), natal.origin_palace_branch()),
+    ] {
+        assert_eq!(palace_at_branch(natal, branch).name(), name);
+    }
+
+    let origin = palace_at_branch(natal, natal.origin_palace_branch());
+    assert_eq!(origin.stem(), birth_stem);
+
+    for key in StarKey::ALL {
+        let target_branch = star_branches[star_index(key)]
+            .expect("every published star identity has one placement");
+        let star = palace_at_branch(natal, target_branch)
+            .stars()
+            .iter()
+            .find(|star| star.key() == key)
+            .expect("the indexed branch contains the star");
+
+        assert_eq!(
+            star.origin_transformation(),
+            expected_transformation_from(natal, natal.origin_palace_branch(), key),
+        );
+        assert_eq!(
+            star.self_transformations().outward(),
+            expected_transformation_from(natal, target_branch, key),
+        );
+        assert_eq!(
+            star.self_transformations().inward(),
+            expected_transformation_from(natal, opposite(target_branch), key),
+        );
+    }
+}
+
+#[test]
+#[ignore = "exhaustive optimization baseline; run explicitly in release mode"]
+fn every_valid_normalized_input_preserves_natal_graph_invariants() {
+    for gender in [Gender::Yin, Gender::Yang] {
+        for cycle_index in 0..60 {
+            let stem = STEMS[cycle_index % STEMS.len()];
+            let branch = BRANCHES[cycle_index % BRANCHES.len()];
+
+            for month in 0..12 {
+                for day in 1..=30 {
+                    for hour in 0..12 {
+                        let input = ZiweiInput::try_new(gender, stem, branch, month, day, hour)
+                            .expect("sexagenary cycle and lunar fields are valid");
+                        let natal = Natal::from_input(input);
+
+                        assert_natal_graph_invariants(&natal, stem);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/ziwei_core/Cargo.toml
+++ b/crates/ziwei_core/Cargo.toml
@@ -10,6 +10,19 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+arrayvec.workspace = true
+
+[dev-dependencies]
+allocation-counter.workspace = true
+criterion.workspace = true
+
+[[bench]]
+name = "natal"
+harness = false
+
+[[bench]]
+name = "natal_allocations"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/ziwei_core/benches/natal.rs
+++ b/crates/ziwei_core/benches/natal.rs
@@ -1,0 +1,39 @@
+//! Representative `Natal` construction latency baselines.
+
+use std::hint::black_box;
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use ziwei_core::Natal;
+
+mod support;
+
+use support::{CASE_COUNT, representative_births, representative_inputs};
+
+fn benchmark_natal(c: &mut Criterion) {
+    let births = representative_births();
+    let inputs = representative_inputs();
+    let mut group = c.benchmark_group("natal/sexagenary_cycle");
+    group.throughput(Throughput::Elements(
+        u64::try_from(CASE_COUNT).expect("case count fits in u64"),
+    ));
+
+    group.bench_function("from_input", |b| {
+        b.iter(|| {
+            for input in black_box(&inputs) {
+                black_box(Natal::from_input(black_box(*input)));
+            }
+        });
+    });
+    group.bench_function("from_birth", |b| {
+        b.iter(|| {
+            for birth in black_box(&births) {
+                black_box(Natal::from_birth(black_box(*birth)));
+            }
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, benchmark_natal);
+criterion_main!(benches);

--- a/crates/ziwei_core/benches/natal_allocations.rs
+++ b/crates/ziwei_core/benches/natal_allocations.rs
@@ -1,0 +1,41 @@
+//! Representative `Natal` construction allocation baselines.
+
+use std::{hint::black_box, mem::size_of};
+
+use allocation_counter::{AllocationInfo, measure};
+use ziwei_core::Natal;
+
+mod support;
+
+use support::{representative_births, representative_inputs};
+
+fn print_allocations(name: &str, allocations: AllocationInfo) {
+    println!(
+        "{name}: total_allocations={}, total_bytes={}, peak_allocations={}, peak_bytes={}",
+        allocations.count_total,
+        allocations.bytes_total,
+        allocations.count_max,
+        allocations.bytes_max,
+    );
+}
+
+fn main() {
+    let births = representative_births();
+    let inputs = representative_inputs();
+
+    let _ = measure(|| {});
+    let from_input = measure(|| {
+        for input in black_box(&inputs) {
+            black_box(Natal::from_input(black_box(*input)));
+        }
+    });
+    let from_birth = measure(|| {
+        for birth in black_box(&births) {
+            black_box(Natal::from_birth(black_box(*birth)));
+        }
+    });
+
+    println!("Natal: size_bytes={}", size_of::<Natal>());
+    print_allocations("from_input", from_input);
+    print_allocations("from_birth", from_birth);
+}

--- a/crates/ziwei_core/benches/support/mod.rs
+++ b/crates/ziwei_core/benches/support/mod.rs
@@ -1,0 +1,78 @@
+use ziwei_core::{Branch, Gender, Stem, ZiweiBirth, ZiweiInput};
+
+pub(crate) const CASE_COUNT: usize = 60;
+
+const STEMS: [Stem; 10] = [
+    Stem::Jia,
+    Stem::Yi,
+    Stem::Bing,
+    Stem::Ding,
+    Stem::Wu,
+    Stem::Ji,
+    Stem::Geng,
+    Stem::Xin,
+    Stem::Ren,
+    Stem::Gui,
+];
+
+const BRANCHES: [Branch; 12] = [
+    Branch::Zi,
+    Branch::Chou,
+    Branch::Yin,
+    Branch::Mao,
+    Branch::Chen,
+    Branch::Si,
+    Branch::Wu,
+    Branch::Wei,
+    Branch::Shen,
+    Branch::You,
+    Branch::Xu,
+    Branch::Hai,
+];
+
+pub(crate) fn representative_births() -> [ZiweiBirth; CASE_COUNT] {
+    std::array::from_fn(|index| {
+        ZiweiBirth::try_new(
+            gender(index),
+            1984 + i32::try_from(index).expect("case index fits in i32"),
+            month(index),
+            day(index),
+            hour(index),
+        )
+        .expect("representative birth is valid")
+    })
+}
+
+pub(crate) fn representative_inputs() -> [ZiweiInput; CASE_COUNT] {
+    std::array::from_fn(|index| {
+        ZiweiInput::try_new(
+            gender(index),
+            STEMS[index % STEMS.len()],
+            BRANCHES[index % BRANCHES.len()],
+            month(index),
+            day(index),
+            hour(index),
+        )
+        .expect("representative input is valid")
+    })
+}
+
+const fn gender(index: usize) -> Gender {
+    if index % 4 < 2 {
+        Gender::Yang
+    } else {
+        Gender::Yin
+    }
+}
+
+fn month(index: usize) -> u8 {
+    u8::try_from(index * 5 % 12).expect("month fits in u8")
+}
+
+fn day(index: usize) -> u8 {
+    u8::try_from(index * 7 % 30 + 1).expect("day fits in u8")
+}
+
+fn hour(index: usize) -> u8 {
+    u8::try_from((index * 7 + 3) % 12).expect("hour fits in u8")
+}

--- a/crates/ziwei_core/src/natal.rs
+++ b/crates/ziwei_core/src/natal.rs
@@ -83,7 +83,7 @@ impl NatalContext {
 ///
 /// let _ = Natal {};
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Natal {
     context: NatalContext,
     zodiac: Zodiac,

--- a/crates/ziwei_core/src/palace.rs
+++ b/crates/ziwei_core/src/palace.rs
@@ -1,11 +1,16 @@
 //! 十二宫名、宫位及宫位四化关系。
 
+use arrayvec::ArrayVec;
+
 use super::{
     branch::Branch,
     star::{Star, StarKey},
     stem::Stem,
     transformation::Transformation,
 };
+
+pub(crate) const MAX_STARS_PER_PALACE: usize = 6;
+pub(crate) type PalaceStars = ArrayVec<Star, MAX_STARS_PER_PALACE>;
 
 /// 十二宫名，自命宫起按经典逆布次序排列。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -142,7 +147,7 @@ pub struct Palace {
     name: PalaceName,
     branch: Branch,
     stem: Stem,
-    stars: Vec<Star>,
+    stars: PalaceStars,
     transformations: [PalaceTransformation; 4],
 }
 
@@ -152,7 +157,7 @@ impl Palace {
         name: PalaceName,
         branch: Branch,
         stem: Stem,
-        stars: Vec<Star>,
+        stars: PalaceStars,
         transformations: [PalaceTransformation; 4],
     ) -> Self {
         Self {
@@ -181,7 +186,7 @@ impl Palace {
 
     /// 落在本宫的星曜，顺序遵循 [`StarKey::ALL`]。
     pub fn stars(&self) -> &[Star] {
-        &self.stars
+        self.stars.as_slice()
     }
 
     /// 以本宫为源宫的四条关系，顺序固定为 `A / B / C / D`。
@@ -210,11 +215,13 @@ mod tests {
             Branch::Zi,
             StarKey::ZiWei,
         );
+        let mut stars = PalaceStars::new();
+        stars.push(star);
         let palace = Palace::new(
             PalaceName::Ming,
             Branch::Zi,
             Stem::Jia,
-            vec![star],
+            stars,
             [relation; 4],
         );
 

--- a/crates/ziwei_core/src/pipeline.rs
+++ b/crates/ziwei_core/src/pipeline.rs
@@ -4,17 +4,22 @@ use super::{
     branch::Branch,
     decade::build_decades,
     natal::{Natal, NatalContext},
-    palace::{Palace, PalaceName, PalaceTransformation},
+    palace::{Palace, PalaceName, PalaceStars, PalaceTransformation},
     placement::{
         PalaceSeed, build_palace_seeds, bureau_from_ming_palace, compute_ming_shen_branches,
         compute_palace_stems, merge_assistants, place_assistants, place_major_stars,
     },
     position::branch_from_yin0,
     star::{Star, StarKey, StarSelfTransformations},
-    stem::Stem,
     transformation::Transformation,
     zodiac::Zodiac,
 };
+
+struct TransformationFacts {
+    palace_transformations_by_branch: [[PalaceTransformation; 4]; 12],
+    origin_transformations_by_star: [Option<Transformation>; 18],
+    self_transformations_by_star: [StarSelfTransformations; 18],
+}
 
 /// 由归一化上下文计算完整本命盘。
 pub(crate) fn build_natal(context: NatalContext) -> Natal {
@@ -26,34 +31,36 @@ pub(crate) fn build_natal(context: NatalContext) -> Natal {
         place_major_stars(context.day(), bureau.number()),
         place_assistants(context.month(), context.hour()),
     );
+    let origin_palace_branch = context.birth_stem().origin_palace_branch();
+    let transformation_facts =
+        build_transformation_facts(origin_palace_branch, &palace_seeds, &star_branches);
 
-    let mut stars_by_branch: [Vec<Star>; 12] = std::array::from_fn(|_| Vec::new());
+    let mut stars_by_branch: [PalaceStars; 12] = std::array::from_fn(|_| PalaceStars::new());
     for key in StarKey::ALL {
         let branch = star_branches[key.index()];
-        let origin_transformation = find_origin_transformation(context.birth_stem(), key);
-        let self_transformations = compute_self_transformations(key, branch, &palace_seeds);
-        stars_by_branch[branch.index()].push(Star::new(
+        let star = Star::new(
             key,
-            origin_transformation,
-            self_transformations,
-        ));
+            transformation_facts.origin_transformations_by_star[key.index()],
+            transformation_facts.self_transformations_by_star[key.index()],
+        );
+        stars_by_branch[branch.index()]
+            .try_push(star)
+            .expect("a palace contains at most six supported stars");
     }
 
     let palaces = std::array::from_fn(|yin0| {
         let yin0 = u8::try_from(yin0).expect("twelve palaces fit in u8");
         let branch = branch_from_yin0(yin0);
         let seed = palace_seeds[branch.index()];
-        let transformations = build_palace_transformations(seed, &palace_seeds, &star_branches);
         Palace::new(
             seed.name,
             seed.branch,
             seed.stem,
             std::mem::take(&mut stars_by_branch[branch.index()]),
-            transformations,
+            transformation_facts.palace_transformations_by_branch[branch.index()],
         )
     });
 
-    let origin_palace_branch = context.birth_stem().origin_palace_branch();
     let ming_palace = palace_name_at(ming_shen_branches.ming, &palace_seeds);
     let shen_palace = palace_name_at(ming_shen_branches.shen, &palace_seeds);
     let origin_palace = palace_name_at(origin_palace_branch, &palace_seeds);
@@ -85,61 +92,65 @@ fn palace_name_at(branch: Branch, palace_seeds: &[PalaceSeed; 12]) -> PalaceName
     palace_seeds[branch.index()].name
 }
 
-fn find_origin_transformation(birth_stem: Stem, key: StarKey) -> Option<Transformation> {
-    Transformation::ALL
-        .into_iter()
-        .find(|transformation| birth_stem.transformation_star(*transformation) == key)
-}
-
-fn compute_self_transformations(
-    key: StarKey,
-    target_branch: Branch,
+fn build_transformation_facts(
+    origin_palace_branch: Branch,
     palace_seeds: &[PalaceSeed; 12],
-) -> StarSelfTransformations {
-    let mut inward = None;
-    let mut outward = None;
+    star_branches: &[Branch; 18],
+) -> TransformationFacts {
+    let mut origin_transformations_by_star = [None; 18];
+    let mut inward_transformations_by_star = [None; 18];
+    let mut outward_transformations_by_star = [None; 18];
 
-    for source in palace_seeds {
-        for transformation in Transformation::ALL {
-            if source.stem.transformation_star(transformation) != key {
-                continue;
+    let palace_transformations_by_branch = std::array::from_fn(|branch_index| {
+        let source = palace_seeds[branch_index];
+        std::array::from_fn(|transformation_index| {
+            let transformation = Transformation::ALL[transformation_index];
+            let star_key = source.stem.transformation_star(transformation);
+            let star_index = star_key.index();
+            let target_branch = star_branches[star_index];
+
+            if source.branch == origin_palace_branch {
+                debug_assert!(
+                    origin_transformations_by_star[star_index].is_none(),
+                    "each origin transformation targets a distinct star"
+                );
+                origin_transformations_by_star[star_index] = Some(transformation);
             }
             if source.branch == target_branch {
                 debug_assert!(
-                    outward.is_none(),
+                    outward_transformations_by_star[star_index].is_none(),
                     "a star has at most one outward self-transformation"
                 );
-                outward = Some(transformation);
+                outward_transformations_by_star[star_index] = Some(transformation);
             }
             if source.branch.opposite() == target_branch {
                 debug_assert!(
-                    inward.is_none(),
+                    inward_transformations_by_star[star_index].is_none(),
                     "a star has at most one inward self-transformation"
                 );
-                inward = Some(transformation);
+                inward_transformations_by_star[star_index] = Some(transformation);
             }
-        }
-    }
 
-    StarSelfTransformations::new(inward, outward)
-}
-
-fn build_palace_transformations(
-    source: PalaceSeed,
-    palace_seeds: &[PalaceSeed; 12],
-    star_branches: &[Branch; 18],
-) -> [PalaceTransformation; 4] {
-    std::array::from_fn(|index| {
-        let transformation = Transformation::ALL[index];
-        let star_key = source.stem.transformation_star(transformation);
-        let target_branch = star_branches[star_key.index()];
-        PalaceTransformation::new(
-            source.name,
-            source.branch,
-            transformation,
-            palace_name_at(target_branch, palace_seeds),
-            target_branch,
-            star_key,
+            PalaceTransformation::new(
+                source.name,
+                source.branch,
+                transformation,
+                palace_name_at(target_branch, palace_seeds),
+                target_branch,
+                star_key,
+            )
+        })
+    });
+    let self_transformations_by_star = std::array::from_fn(|star_index| {
+        StarSelfTransformations::new(
+            inward_transformations_by_star[star_index],
+            outward_transformations_by_star[star_index],
         )
-    })
+    });
+
+    TransformationFacts {
+        palace_transformations_by_branch,
+        origin_transformations_by_star,
+        self_transformations_by_star,
+    }
 }


### PR DESCRIPTION
## 变更

- 将生年四化、宫位四化与星曜自化合并为一次 48 条关系扫描，删除重复遍历。
- 使用 `ArrayVec<Star, 6>` 内联保存每宫星曜，消除排盘过程中的堆分配，并保持 `Palace::stars() -> &[Star]` 不变。
- 移除没有生产调用的 `Natal: Clone`，明确不可变命盘应通过借用或共享所有权使用。
- 新增覆盖完整六十甲子的 Criterion 延迟基准和分配基准。
- 新增覆盖全部 518,400 种合法归一化输入的穷举公共契约测试。

## 影响

- 60 张代表性命盘的 `from_input` 耗时约 14.734 µs，`from_birth` 耗时约 14.504 µs。
- 相比同一单遍管线使用 `Vec<Star>`，构造延迟降低约 46%，每 60 张命盘的分配由 640 次 / 10,240 B 降为 0。
- `Natal` 从 2,192 B 降为 2,188 B。
- 移除 `Clone for Natal` 属于破坏性 API 变更；调用方应借用 `&Natal`，需要共享所有权时包装为 `Rc<Natal>` / `Arc<Natal>`。

## 验证

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`（43 passed，1 ignored）
- `cargo test -p ziwei --test natal_exhaustive --release -- --ignored`（1 passed）
- `cargo bench -p ziwei_core --bench natal_allocations`（两条构造路径均为 0 allocations / 0 bytes）
- `cargo bench -p ziwei_core --bench natal -- --noplot`
