### PR TITLE
perf(core): 优化安星与宫位组装

### DIFF
--- a/crates/ziwei_core/src/domain/placement.rs
+++ b/crates/ziwei_core/src/domain/placement.rs
@@ -2,6 +2,13 @@
 //!
 //! 本模块内部同时使用两套零点（ADR-0007）：
 //! 子序以子为零，用于宫数组下标；寅环以寅为零，用于口诀安命、安星与五虎遁顺布。
+//!
+//! # 性能设计
+//!
+//! 安星公式保留为 `const fn`，并在编译期生成按局日、紫微坐标、月份和时辰分解的小表。
+//! 运行时只查询这些小表、复制十八个星曜槽并覆盖四个辅星槽，不再执行公式中的除法和环形取模。
+//! 分解表避免了完整输入笛卡尔积的体积；表值由下方公式生成，不手工维护。
+//! 修改表结构或恢复运行时公式时，应以 `benches/natal.rs` 的端到端基准重新验证。
 
 use super::{Branch, FiveElementBureau, PalaceName, StarKey, Stem};
 
@@ -10,6 +17,27 @@ const BRANCH_INDEX_TO_YIN0: [u8; 12] = [10, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 
 /// 寅环 → 子序：寅(0)→2 … 子(10)→0，丑(11)→1。
 const YIN0_TO_BRANCH_INDEX: [u8; 12] = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0, 1];
+
+/// 五行局 × 农历日 → 紫微星寅环坐标。
+///
+/// 行依次为水二、木三、金四、土五、火六局；列为 `day - 1`，即初一到三十。
+const ZI_WEI_YIN0_BY_BUREAU_DAY: [[u8; 30]; 5] = build_zi_wei_yin0_by_bureau_day();
+
+/// 紫微星寅环坐标 → 十四主星落宫。
+///
+/// 行为紫微星的寅环坐标 `0..12`，列与 [`StarKey::index`] 对齐；`0..14` 是十四主星，
+/// `14..18` 是编译期占位槽，运行时必由辅星表覆盖后才返回。
+const MAJOR_BRANCHES_BY_ZI_WEI_YIN0: [[Branch; 18]; 12] = build_major_branches_by_zi_wei_yin0();
+
+/// 农历月 → 左辅、右弼落宫。
+///
+/// 行为 `month`（`0` 表示正月），两列依次与左辅、右弼对应。
+const ZUO_YOU_BY_MONTH: [[Branch; 2]; 12] = build_zuo_you_by_month();
+
+/// 时辰 → 文昌、文曲落宫。
+///
+/// 行为 `hour`（`0` 表示子时），两列依次与文昌、文曲对应。
+const CHANG_QU_BY_HOUR: [[Branch; 2]; 12] = build_chang_qu_by_hour();
 
 const fn branch_index_to_yin0(branch_index: u8) -> u8 {
     BRANCH_INDEX_TO_YIN0[branch_index.rem_euclid(12) as usize]
@@ -36,15 +64,6 @@ pub(crate) struct PalacePlacement {
     pub(crate) name: PalaceName,
     pub(crate) branch: Branch,
     pub(crate) stem: Stem,
-}
-
-/// 首批四颗辅星的落宫地支。
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct MinorStarBranches {
-    zuo_fu: Branch,
-    you_bi: Branch,
-    wen_chang: Branch,
-    wen_qu: Branch,
 }
 
 /// 寅起正月；命宫逆时、身宫顺时。
@@ -105,20 +124,66 @@ pub(crate) fn compute_palace_placements(
     placements_by_branch
 }
 
-/// 计算首批四颗辅星的落宫地支。
-pub(crate) fn compute_minor_star_branches(month: u8, hour: u8) -> MinorStarBranches {
-    MinorStarBranches {
-        zuo_fu: branch_from_yin0((2 + i32::from(month)).rem_euclid(12) as u8),
-        you_bi: branch_from_yin0((8 - i32::from(month)).rem_euclid(12) as u8),
-        wen_chang: branch_from_yin0((8 - i32::from(hour)).rem_euclid(12) as u8),
-        wen_qu: branch_from_yin0((2 + i32::from(hour)).rem_euclid(12) as u8),
+/// 一次完成十四主星与首批四颗辅星的落宫计算和十八槽组装。
+///
+/// 输入沿用已验证出生上下文的编码：`day` 为 `1..=30`，`month` 与 `hour` 为 `0..=11`；
+/// 返回数组与 [`StarKey::index`] 对齐。
+///
+/// 热路径依次查询四张分解表并覆盖四个辅星槽，不执行安星公式中的除法和环形取模。
+pub(crate) fn compute_star_branches(
+    day: u8,
+    bureau: FiveElementBureau,
+    month: u8,
+    hour: u8,
+) -> [Branch; 18] {
+    let day_index = usize::from(
+        day.checked_sub(1)
+            .expect("validated lunar day starts at one"),
+    );
+    let zi_wei_yin0 = ZI_WEI_YIN0_BY_BUREAU_DAY[bureau_index(bureau)][day_index];
+    let mut branches_by_star = MAJOR_BRANCHES_BY_ZI_WEI_YIN0[usize::from(zi_wei_yin0)];
+
+    let [zuo_fu, you_bi] = ZUO_YOU_BY_MONTH[usize::from(month)];
+    let [wen_chang, wen_qu] = CHANG_QU_BY_HOUR[usize::from(hour)];
+    branches_by_star[StarKey::ZuoFu.index()] = zuo_fu;
+    branches_by_star[StarKey::YouBi.index()] = you_bi;
+    branches_by_star[StarKey::WenChang.index()] = wen_chang;
+    branches_by_star[StarKey::WenQu.index()] = wen_qu;
+    branches_by_star
+}
+
+/// 映射到 [`ZI_WEI_YIN0_BY_BUREAU_DAY`] 的行顺序。
+const fn bureau_index(bureau: FiveElementBureau) -> usize {
+    match bureau {
+        FiveElementBureau::WaterTwo => 0,
+        FiveElementBureau::WoodThree => 1,
+        FiveElementBureau::MetalFour => 2,
+        FiveElementBureau::EarthFive => 3,
+        FiveElementBureau::FireSix => 4,
     }
 }
 
-/// 计算十四主星的落宫地支。
-pub(crate) fn compute_major_star_branches(day: u8, bureau_number: u8) -> [Branch; 18] {
-    let bureau_number = i32::from(bureau_number);
-    let day = i32::from(day);
+/// 在编译期从紫微起点公式生成五局三十日表。
+const fn build_zi_wei_yin0_by_bureau_day() -> [[u8; 30]; 5] {
+    let mut table = [[0; 30]; 5];
+    let mut bureau_index = 0;
+    while bureau_index < table.len() {
+        let bureau_number = bureau_index as u8 + 2;
+        let mut day_index = 0;
+        while day_index < table[bureau_index].len() {
+            table[bureau_index][day_index] =
+                compute_zi_wei_yin0(day_index as u8 + 1, bureau_number);
+            day_index += 1;
+        }
+        bureau_index += 1;
+    }
+    table
+}
+
+/// 紫微起点公式：日数除以局数取上界商，补数为奇数则逆退、偶数则顺进。
+const fn compute_zi_wei_yin0(day: u8, bureau_number: u8) -> u8 {
+    let bureau_number = bureau_number as i32;
+    let day = day as i32;
     let ceiling_quotient = (day + bureau_number - 1) / bureau_number;
     let shortfall = ceiling_quotient * bureau_number - day;
     let signed_shortfall = match shortfall {
@@ -126,25 +191,49 @@ pub(crate) fn compute_major_star_branches(day: u8, bureau_number: u8) -> [Branch
         value if value.rem_euclid(2) == 1 => -value,
         value => value,
     };
-    let zi_wei_yin0 = ((ceiling_quotient - 1) + signed_shortfall).rem_euclid(12) as u8;
-    let tian_fu_yin0 = (-i32::from(zi_wei_yin0)).rem_euclid(12) as u8;
+    ((ceiling_quotient - 1) + signed_shortfall).rem_euclid(12) as u8
+}
 
+/// 在编译期生成十二个紫微起点对应的十四主星落宫行。
+const fn build_major_branches_by_zi_wei_yin0() -> [[Branch; 18]; 12] {
+    let mut table = [[Branch::Zi; 18]; 12];
+    let mut zi_wei_yin0 = 0;
+    while zi_wei_yin0 < table.len() {
+        table[zi_wei_yin0] = compute_major_branches_from_zi_wei_yin0(zi_wei_yin0 as u8);
+        zi_wei_yin0 += 1;
+    }
+    table
+}
+
+/// 以一个紫微起点展开紫微系和天府系；末四个辅星槽保持占位值。
+const fn compute_major_branches_from_zi_wei_yin0(zi_wei_yin0: u8) -> [Branch; 18] {
+    let zi_wei_yin0_i32 = zi_wei_yin0 as i32;
+    let tian_fu_yin0 = (-zi_wei_yin0_i32).rem_euclid(12) as u8;
+    let tian_fu_yin0_i32 = tian_fu_yin0 as i32;
     let mut branches_by_star = [Branch::Zi; 18];
-    for (star_key, yin0_offset) in [
+
+    // 数值为相对紫微星的逆行步数。
+    let zi_wei_series = [
         (StarKey::ZiWei, 0),
         (StarKey::TianJi, 1),
         (StarKey::TaiYang, 3),
         (StarKey::WuQu, 4),
         (StarKey::TianTong, 5),
         (StarKey::LianZhen, 8),
-    ] {
+    ];
+    let mut series_index = 0;
+    while series_index < zi_wei_series.len() {
+        let (star_key, yin0_offset) = zi_wei_series[series_index];
         set_star_branch(
             &mut branches_by_star,
             star_key,
-            (i32::from(zi_wei_yin0) - yin0_offset).rem_euclid(12) as u8,
+            (zi_wei_yin0_i32 - yin0_offset).rem_euclid(12) as u8,
         );
+        series_index += 1;
     }
-    for (star_key, yin0_offset) in [
+
+    // 数值为相对天府星的顺行步数。
+    let tian_fu_series = [
         (StarKey::TianFu, 0),
         (StarKey::TaiYin, 1),
         (StarKey::TanLang, 2),
@@ -153,27 +242,47 @@ pub(crate) fn compute_major_star_branches(day: u8, bureau_number: u8) -> [Branch
         (StarKey::TianLiang, 5),
         (StarKey::QiSha, 6),
         (StarKey::PoJun, 10),
-    ] {
+    ];
+    series_index = 0;
+    while series_index < tian_fu_series.len() {
+        let (star_key, yin0_offset) = tian_fu_series[series_index];
         set_star_branch(
             &mut branches_by_star,
             star_key,
-            (i32::from(tian_fu_yin0) + yin0_offset).rem_euclid(12) as u8,
+            (tian_fu_yin0_i32 + yin0_offset).rem_euclid(12) as u8,
         );
+        series_index += 1;
     }
 
     branches_by_star
 }
 
-/// 把首批四颗辅星合并到十八星落宫表。
-pub(crate) fn merge_star_branches(
-    mut branches_by_star: [Branch; 18],
-    minor_star_branches: MinorStarBranches,
-) -> [Branch; 18] {
-    branches_by_star[StarKey::ZuoFu.index()] = minor_star_branches.zuo_fu;
-    branches_by_star[StarKey::YouBi.index()] = minor_star_branches.you_bi;
-    branches_by_star[StarKey::WenChang.index()] = minor_star_branches.wen_chang;
-    branches_by_star[StarKey::WenQu.index()] = minor_star_branches.wen_qu;
-    branches_by_star
+/// 左辅从辰起正月顺行，右弼从戌起正月逆行；在编译期生成十二月表。
+const fn build_zuo_you_by_month() -> [[Branch; 2]; 12] {
+    let mut table = [[Branch::Zi; 2]; 12];
+    let mut month = 0;
+    while month < table.len() {
+        table[month] = [
+            branch_from_yin0((2 + month as i32).rem_euclid(12) as u8),
+            branch_from_yin0((8 - month as i32).rem_euclid(12) as u8),
+        ];
+        month += 1;
+    }
+    table
+}
+
+/// 文昌从戌起子时逆行，文曲从辰起子时顺行；在编译期生成十二时辰表。
+const fn build_chang_qu_by_hour() -> [[Branch; 2]; 12] {
+    let mut table = [[Branch::Zi; 2]; 12];
+    let mut hour = 0;
+    while hour < table.len() {
+        table[hour] = [
+            branch_from_yin0((8 - hour as i32).rem_euclid(12) as u8),
+            branch_from_yin0((2 + hour as i32).rem_euclid(12) as u8),
+        ];
+        hour += 1;
+    }
+    table
 }
 
 const fn set_star_branch(branches_by_star: &mut [Branch; 18], star_key: StarKey, yin0: u8) {
@@ -183,6 +292,75 @@ const fn set_star_branch(branches_by_star: &mut [Branch; 18], star_key: StarKey,
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const BUREAUS: [FiveElementBureau; 5] = [
+        FiveElementBureau::WaterTwo,
+        FiveElementBureau::WoodThree,
+        FiveElementBureau::MetalFour,
+        FiveElementBureau::EarthFive,
+        FiveElementBureau::FireSix,
+    ];
+
+    fn compute_star_branches_by_formula(
+        day: u8,
+        bureau: FiveElementBureau,
+        month: u8,
+        hour: u8,
+    ) -> [Branch; 18] {
+        let bureau_number = i32::from(bureau.number());
+        let day = i32::from(day);
+        let ceiling_quotient = (day + bureau_number - 1) / bureau_number;
+        let shortfall = ceiling_quotient * bureau_number - day;
+        let signed_shortfall = match shortfall {
+            0 => 0,
+            value if value.rem_euclid(2) == 1 => -value,
+            value => value,
+        };
+        let zi_wei_yin0 = ((ceiling_quotient - 1) + signed_shortfall).rem_euclid(12) as u8;
+        let tian_fu_yin0 = (-i32::from(zi_wei_yin0)).rem_euclid(12) as u8;
+
+        let mut branches_by_star = [Branch::Zi; 18];
+        for (star_key, yin0_offset) in [
+            (StarKey::ZiWei, 0),
+            (StarKey::TianJi, 1),
+            (StarKey::TaiYang, 3),
+            (StarKey::WuQu, 4),
+            (StarKey::TianTong, 5),
+            (StarKey::LianZhen, 8),
+        ] {
+            set_star_branch(
+                &mut branches_by_star,
+                star_key,
+                (i32::from(zi_wei_yin0) - yin0_offset).rem_euclid(12) as u8,
+            );
+        }
+        for (star_key, yin0_offset) in [
+            (StarKey::TianFu, 0),
+            (StarKey::TaiYin, 1),
+            (StarKey::TanLang, 2),
+            (StarKey::JuMen, 3),
+            (StarKey::TianXiang, 4),
+            (StarKey::TianLiang, 5),
+            (StarKey::QiSha, 6),
+            (StarKey::PoJun, 10),
+        ] {
+            set_star_branch(
+                &mut branches_by_star,
+                star_key,
+                (i32::from(tian_fu_yin0) + yin0_offset).rem_euclid(12) as u8,
+            );
+        }
+
+        branches_by_star[StarKey::ZuoFu.index()] =
+            branch_from_yin0((2 + i32::from(month)).rem_euclid(12) as u8);
+        branches_by_star[StarKey::YouBi.index()] =
+            branch_from_yin0((8 - i32::from(month)).rem_euclid(12) as u8);
+        branches_by_star[StarKey::WenChang.index()] =
+            branch_from_yin0((8 - i32::from(hour)).rem_euclid(12) as u8);
+        branches_by_star[StarKey::WenQu.index()] =
+            branch_from_yin0((2 + i32::from(hour)).rem_euclid(12) as u8);
+        branches_by_star
+    }
 
     #[test]
     fn coordinate_conversions_round_trip_all_twelve_positions() {
@@ -319,20 +497,20 @@ mod tests {
     #[test]
     fn tian_fu_mirrors_zi_wei_for_every_supported_day_and_bureau() {
         for day in 1..=30u8 {
-            for bureau_number in [2u8, 3, 4, 5, 6] {
-                let major_star_branches = compute_major_star_branches(day, bureau_number);
+            for bureau in BUREAUS {
+                let star_branches = compute_star_branches(day, bureau, 0, 0);
                 let zi_wei_yin0 = branch_index_to_yin0(
-                    u8::try_from(major_star_branches[StarKey::ZiWei.index()].index())
+                    u8::try_from(star_branches[StarKey::ZiWei.index()].index())
                         .expect("branch index fits in u8"),
                 );
                 let tian_fu_yin0 = branch_index_to_yin0(
-                    u8::try_from(major_star_branches[StarKey::TianFu.index()].index())
+                    u8::try_from(star_branches[StarKey::TianFu.index()].index())
                         .expect("branch index fits in u8"),
                 );
                 assert_eq!(
                     tian_fu_yin0,
                     (-i32::from(zi_wei_yin0)).rem_euclid(12) as u8,
-                    "day={day} bureau={bureau_number}"
+                    "day={day} bureau={bureau:?}"
                 );
             }
         }
@@ -384,24 +562,42 @@ mod tests {
     fn minor_star_branches_follow_all_month_hour_formulas() {
         for month in 0..12u8 {
             for hour in 0..12u8 {
-                let minor_star_branches = compute_minor_star_branches(month, hour);
+                let star_branches =
+                    compute_star_branches(1, FiveElementBureau::WaterTwo, month, hour);
 
                 assert_eq!(
-                    minor_star_branches.zuo_fu,
+                    star_branches[StarKey::ZuoFu.index()],
                     branch_from_yin0((2 + i32::from(month)).rem_euclid(12) as u8)
                 );
                 assert_eq!(
-                    minor_star_branches.you_bi,
+                    star_branches[StarKey::YouBi.index()],
                     branch_from_yin0((8 - i32::from(month)).rem_euclid(12) as u8)
                 );
                 assert_eq!(
-                    minor_star_branches.wen_chang,
+                    star_branches[StarKey::WenChang.index()],
                     branch_from_yin0((8 - i32::from(hour)).rem_euclid(12) as u8)
                 );
                 assert_eq!(
-                    minor_star_branches.wen_qu,
+                    star_branches[StarKey::WenQu.index()],
                     branch_from_yin0((2 + i32::from(hour)).rem_euclid(12) as u8)
                 );
+            }
+        }
+    }
+
+    #[test]
+    fn lookup_tables_match_formula_for_every_supported_input() {
+        for bureau in BUREAUS {
+            for day in 1..=30u8 {
+                for month in 0..12u8 {
+                    for hour in 0..12u8 {
+                        assert_eq!(
+                            compute_star_branches(day, bureau, month, hour),
+                            compute_star_branches_by_formula(day, bureau, month, hour),
+                            "day={day} bureau={bureau:?} month={month} hour={hour}"
+                        );
+                    }
+                }
             }
         }
     }

--- a/crates/ziwei_core/src/natal.rs
+++ b/crates/ziwei_core/src/natal.rs
@@ -6,9 +6,8 @@ use super::{
         PalaceStars, PalaceTransformation, Star, StarKey, StarSelfTransformations, Stem,
         Transformation, Zodiac, build_decades,
         placement::{
-            PalacePlacement, branch_from_yin0, bureau_from_ming_palace,
-            compute_major_star_branches, compute_ming_shen_branches, compute_minor_star_branches,
-            compute_palace_placements, compute_palace_stems, merge_star_branches,
+            PalacePlacement, bureau_from_ming_palace, compute_ming_shen_branches,
+            compute_palace_placements, compute_palace_stems, compute_star_branches,
         },
     },
     input::{ZiweiBirth, ZiweiInput},
@@ -127,10 +126,8 @@ impl Natal {
         let bureau = bureau_from_ming_palace(ming_shen.ming_palace, &palace_stems_by_branch);
         let placements_by_branch =
             compute_palace_placements(ming_shen.ming_palace, &palace_stems_by_branch);
-        let branches_by_star = merge_star_branches(
-            compute_major_star_branches(context.day(), bureau.number()),
-            compute_minor_star_branches(context.month(), context.hour()),
-        );
+        let branches_by_star =
+            compute_star_branches(context.day(), bureau, context.month(), context.hour());
         let origin_palace_branch = context.birth_stem().origin_palace_branch();
         let transformation_facts = build_transformation_facts(
             origin_palace_branch,
@@ -151,18 +148,31 @@ impl Natal {
                 .expect("a palace contains at most six supported stars");
         }
 
-        let palaces = std::array::from_fn(|yin0| {
-            let yin0 = u8::try_from(yin0).expect("twelve palaces fit in u8");
-            let branch = branch_from_yin0(yin0);
-            let palace_placement = placements_by_branch[branch.index()];
-            Palace::new(
-                palace_placement.name,
-                palace_placement.branch,
-                palace_placement.stem,
-                std::mem::take(&mut stars_by_branch[branch.index()]),
-                transformation_facts.palace_transformations_by_branch[branch.index()],
+        // 对外宫序固定为寅至丑。端到端基准与发布构建汇编均显示：显式展开可直接组装
+        // 672 B 宫位数组，而 `array::from_fn` 会保留一次整数组搬移；实际构造仍集中在
+        // `take_palace_at_branch`，避免十二份规则实现。
+        let mut take_palace = |branch| {
+            take_palace_at_branch(
+                branch,
+                &placements_by_branch,
+                &mut stars_by_branch,
+                &transformation_facts,
             )
-        });
+        };
+        let palaces = [
+            take_palace(Branch::Yin),
+            take_palace(Branch::Mao),
+            take_palace(Branch::Chen),
+            take_palace(Branch::Si),
+            take_palace(Branch::Wu),
+            take_palace(Branch::Wei),
+            take_palace(Branch::Shen),
+            take_palace(Branch::You),
+            take_palace(Branch::Xu),
+            take_palace(Branch::Hai),
+            take_palace(Branch::Zi),
+            take_palace(Branch::Chou),
+        ];
 
         let ming_palace = palace_name_at(ming_shen.ming_palace, &placements_by_branch);
         let shen_palace = palace_name_at(ming_shen.shen_palace, &placements_by_branch);
@@ -254,6 +264,22 @@ impl Natal {
 
 fn palace_name_at(branch: Branch, placements_by_branch: &[PalacePlacement; 12]) -> PalaceName {
     placements_by_branch[branch.index()].name
+}
+
+fn take_palace_at_branch(
+    branch: Branch,
+    placements_by_branch: &[PalacePlacement; 12],
+    stars_by_branch: &mut [PalaceStars; 12],
+    transformation_facts: &TransformationFacts,
+) -> Palace {
+    let palace_placement = placements_by_branch[branch.index()];
+    Palace::new(
+        palace_placement.name,
+        palace_placement.branch,
+        palace_placement.stem,
+        std::mem::take(&mut stars_by_branch[branch.index()]),
+        transformation_facts.palace_transformations_by_branch[branch.index()],
+    )
 }
 
 fn build_transformation_facts(


### PR DESCRIPTION
## 变更

- 将十四主星与首批四颗辅星的落宫计算收敛为一次 `compute_star_branches` 调用。
- 使用由 `const fn` 公式生成的分解查表，移除运行时安星公式中的除法与环形取模。
- 显式组装固定宫序，消除发布构建中一次 672 B 宫位数组搬移。
- 增加查表与公式的全输入空间对照测试，并补充常量语义和性能设计注释。

## 影响

- 不改变公共接口和排盘结果。
- `Natal` 构造保持零堆分配。
- 本地 Apple M4 Criterion 结果：
  - `from_input`：约 221 ns/盘，约 452 万盘/秒。
  - `from_birth`：约 219 ns/盘，约 457 万盘/秒。
  - 宫位组装优化相对同一安星实现的基线提升约 3.1%–4.9%。

## 验证

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --locked`（44 passed，1 ignored）
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --locked`
- 518,400 组公开输入不变量穷举验证通过
