### PR TITLE
refactor(core): 收拢四化事实组装

### DIFF
--- a/crates/ziwei_core/src/domain/mod.rs
+++ b/crates/ziwei_core/src/domain/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod placement;
 mod star;
 mod stem;
 mod transformation;
+mod transformation_facts;
 mod zodiac;
 
 pub use branch::Branch;
@@ -22,6 +23,7 @@ pub use zodiac::Zodiac;
 pub(crate) use decade::build_decades;
 pub(crate) use palace::PalaceStars;
 pub(crate) use star::{star_category, star_galaxy};
+pub(crate) use transformation_facts::TransformationFacts;
 
 /// 命主的性别（阴阳）。
 ///

--- a/crates/ziwei_core/src/domain/placement.rs
+++ b/crates/ziwei_core/src/domain/placement.rs
@@ -54,9 +54,23 @@ pub(crate) const fn branch_from_yin0(yin0: u8) -> Branch {
 /// 尚未附加星曜与四化关系的宫位落位。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct PalacePlacement {
-    pub(crate) name: PalaceName,
-    pub(crate) branch: Branch,
-    pub(crate) stem: Stem,
+    name: PalaceName,
+    branch: Branch,
+    stem: Stem,
+}
+
+impl PalacePlacement {
+    pub(crate) const fn name(self) -> PalaceName {
+        self.name
+    }
+
+    pub(crate) const fn branch(self) -> Branch {
+        self.branch
+    }
+
+    pub(crate) const fn stem(self) -> Stem {
+        self.stem
+    }
 }
 
 /// 寅起正月，逆时安命宫。
@@ -117,6 +131,14 @@ pub(crate) fn compute_palace_placements(
     }
 
     placements_by_branch
+}
+
+/// 返回指定地支上的宫名。
+pub(crate) const fn palace_name_at(
+    branch: Branch,
+    placements_by_branch: &[PalacePlacement; 12],
+) -> PalaceName {
+    placements_by_branch[branch.index()].name
 }
 
 /// 一次完成十四主星与首批四颗辅星的落宫计算和十八槽组装。

--- a/crates/ziwei_core/src/domain/transformation_facts.rs
+++ b/crates/ziwei_core/src/domain/transformation_facts.rs
@@ -1,0 +1,106 @@
+//! 本命盘四化关系及目标星曜四化事实的内部组装。
+
+use super::{
+    branch::Branch,
+    palace::PalaceTransformation,
+    placement::{PalacePlacement, palace_name_at},
+    star::{StarName, StarSelfTransformations},
+    transformation::Transformation,
+};
+
+/// `Natal` 组装阶段使用的完整四化事实。
+pub(crate) struct TransformationFacts {
+    palace_transformations_by_branch: [[PalaceTransformation; 4]; 12],
+    origin_transformations_by_star: [Option<Transformation>; 18],
+    self_transformations_by_star: [StarSelfTransformations; 18],
+}
+
+impl TransformationFacts {
+    /// 从十二宫落位与十八星落支一次构建全部四化事实。
+    pub(crate) fn build(
+        origin_palace_branch: Branch,
+        placements_by_branch: &[PalacePlacement; 12],
+        branches_by_star: &[Branch; 18],
+    ) -> Self {
+        let mut origin_transformations_by_star = [None; 18];
+        let mut inward_transformations_by_star = [None; 18];
+        let mut outward_transformations_by_star = [None; 18];
+
+        let palace_transformations_by_branch = std::array::from_fn(|branch_index| {
+            let source = placements_by_branch[branch_index];
+            let source_name = source.name();
+            let source_branch = source.branch();
+            let source_stem = source.stem();
+            std::array::from_fn(|transformation_index| {
+                let transformation = Transformation::ALL[transformation_index];
+                let star_name = source_stem.transformation_star(transformation);
+                let star_index = star_name.index();
+                let target_branch = branches_by_star[star_index];
+
+                if source_branch == origin_palace_branch {
+                    debug_assert!(
+                        origin_transformations_by_star[star_index].is_none(),
+                        "each origin transformation targets a distinct star"
+                    );
+                    origin_transformations_by_star[star_index] = Some(transformation);
+                }
+                if source_branch == target_branch {
+                    debug_assert!(
+                        outward_transformations_by_star[star_index].is_none(),
+                        "a star has at most one outward self-transformation"
+                    );
+                    outward_transformations_by_star[star_index] = Some(transformation);
+                }
+                if source_branch.opposite() == target_branch {
+                    debug_assert!(
+                        inward_transformations_by_star[star_index].is_none(),
+                        "a star has at most one inward self-transformation"
+                    );
+                    inward_transformations_by_star[star_index] = Some(transformation);
+                }
+
+                PalaceTransformation::new(
+                    source_name,
+                    source_branch,
+                    transformation,
+                    palace_name_at(target_branch, placements_by_branch),
+                    target_branch,
+                    star_name,
+                )
+            })
+        });
+        let self_transformations_by_star = std::array::from_fn(|star_index| {
+            StarSelfTransformations::new(
+                inward_transformations_by_star[star_index],
+                outward_transformations_by_star[star_index],
+            )
+        });
+
+        Self {
+            palace_transformations_by_branch,
+            origin_transformations_by_star,
+            self_transformations_by_star,
+        }
+    }
+
+    /// 指定宫位发出的四条四化关系。
+    pub(crate) const fn palace_transformations(&self, branch: Branch) -> [PalaceTransformation; 4] {
+        self.palace_transformations_by_branch[branch.index()]
+    }
+
+    /// 指定星曜承接的生年四化。
+    pub(crate) const fn origin_transformation(
+        &self,
+        star_name: StarName,
+    ) -> Option<Transformation> {
+        self.origin_transformations_by_star[star_name.index()]
+    }
+
+    /// 指定星曜的向心、离心自化。
+    pub(crate) const fn self_transformations(
+        &self,
+        star_name: StarName,
+    ) -> StarSelfTransformations {
+        self.self_transformations_by_star[star_name.index()]
+    }
+}

--- a/crates/ziwei_core/src/natal.rs
+++ b/crates/ziwei_core/src/natal.rs
@@ -3,12 +3,11 @@
 use super::{
     domain::{
         Branch, Decade, DecadeDirection, FiveElementBureau, Gender, Palace, PalaceName,
-        PalaceStars, PalaceTransformation, Star, StarName, StarSelfTransformations, Stem,
-        Transformation, Zodiac, build_decades,
+        PalaceStars, Star, StarName, Stem, TransformationFacts, Zodiac, build_decades,
         placement::{
             PalacePlacement, bureau_from_ming_palace, compute_ming_palace_branch,
             compute_palace_placements, compute_palace_stems, compute_shen_palace_branch,
-            compute_star_branches,
+            compute_star_branches, palace_name_at,
         },
         star_category, star_galaxy,
     },
@@ -102,12 +101,6 @@ pub struct Natal {
     decades: [Decade; 12],
 }
 
-struct TransformationFacts {
-    palace_transformations_by_branch: [[PalaceTransformation; 4]; 12],
-    origin_transformations_by_star: [Option<Transformation>; 18],
-    self_transformations_by_star: [StarSelfTransformations; 18],
-}
-
 /// 从含历法层归一化农历年序号的已验证输入创建本命盘。
 pub fn create_from_birth(birth: ZiweiBirth) -> Natal {
     let year = birth.year();
@@ -130,7 +123,7 @@ fn create_from_context(context: NatalContext) -> Natal {
     let branches_by_star =
         compute_star_branches(context.day(), bureau, context.month(), context.hour());
     let origin_palace_branch = context.birth_stem().origin_palace_branch();
-    let transformation_facts = build_transformation_facts(
+    let transformation_facts = TransformationFacts::build(
         origin_palace_branch,
         &placements_by_branch,
         &branches_by_star,
@@ -143,8 +136,8 @@ fn create_from_context(context: NatalContext) -> Natal {
             name,
             star_category(name),
             star_galaxy(name),
-            transformation_facts.origin_transformations_by_star[name.index()],
-            transformation_facts.self_transformations_by_star[name.index()],
+            transformation_facts.origin_transformation(name),
+            transformation_facts.self_transformations(name),
         );
         stars_by_branch[branch.index()]
             .try_push(star)
@@ -259,10 +252,6 @@ impl Natal {
     }
 }
 
-fn palace_name_at(branch: Branch, placements_by_branch: &[PalacePlacement; 12]) -> PalaceName {
-    placements_by_branch[branch.index()].name
-}
-
 fn take_palace_at_branch(
     branch: Branch,
     placements_by_branch: &[PalacePlacement; 12],
@@ -271,75 +260,12 @@ fn take_palace_at_branch(
 ) -> Palace {
     let palace_placement = placements_by_branch[branch.index()];
     Palace::new(
-        palace_placement.name,
-        palace_placement.branch,
-        palace_placement.stem,
+        palace_placement.name(),
+        palace_placement.branch(),
+        palace_placement.stem(),
         std::mem::take(&mut stars_by_branch[branch.index()]),
-        transformation_facts.palace_transformations_by_branch[branch.index()],
+        transformation_facts.palace_transformations(branch),
     )
-}
-
-fn build_transformation_facts(
-    origin_palace_branch: Branch,
-    placements_by_branch: &[PalacePlacement; 12],
-    branches_by_star: &[Branch; 18],
-) -> TransformationFacts {
-    let mut origin_transformations_by_star = [None; 18];
-    let mut inward_transformations_by_star = [None; 18];
-    let mut outward_transformations_by_star = [None; 18];
-
-    let palace_transformations_by_branch = std::array::from_fn(|branch_index| {
-        let source = placements_by_branch[branch_index];
-        std::array::from_fn(|transformation_index| {
-            let transformation = Transformation::ALL[transformation_index];
-            let star_name = source.stem.transformation_star(transformation);
-            let star_index = star_name.index();
-            let target_branch = branches_by_star[star_index];
-
-            if source.branch == origin_palace_branch {
-                debug_assert!(
-                    origin_transformations_by_star[star_index].is_none(),
-                    "each origin transformation targets a distinct star"
-                );
-                origin_transformations_by_star[star_index] = Some(transformation);
-            }
-            if source.branch == target_branch {
-                debug_assert!(
-                    outward_transformations_by_star[star_index].is_none(),
-                    "a star has at most one outward self-transformation"
-                );
-                outward_transformations_by_star[star_index] = Some(transformation);
-            }
-            if source.branch.opposite() == target_branch {
-                debug_assert!(
-                    inward_transformations_by_star[star_index].is_none(),
-                    "a star has at most one inward self-transformation"
-                );
-                inward_transformations_by_star[star_index] = Some(transformation);
-            }
-
-            PalaceTransformation::new(
-                source.name,
-                source.branch,
-                transformation,
-                palace_name_at(target_branch, placements_by_branch),
-                target_branch,
-                star_name,
-            )
-        })
-    });
-    let self_transformations_by_star = std::array::from_fn(|star_index| {
-        StarSelfTransformations::new(
-            inward_transformations_by_star[star_index],
-            outward_transformations_by_star[star_index],
-        )
-    });
-
-    TransformationFacts {
-        palace_transformations_by_branch,
-        origin_transformations_by_star,
-        self_transformations_by_star,
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 变更

- 将四化关系、生年四化和星曜自化的组装收拢到私有 `TransformationFacts` 模块
- 让 `Natal` 构造路径只负责编排，通过 `Branch` 与 `StarName` 读取四化事实
- 收紧 `PalacePlacement` 字段可见性，并集中宫名坐标查询

## 原因

原来的 `natal.rs` 同时承担完整命盘编排与四化关系计算，并直接访问三组平行数组。此次重构将四化规则和存储细节集中到一个内部模块，使构造流程与关系计算各自保持单一职责。

## 影响

不修改公开接口、排盘算法、领域事实或结果物理表示。两个构造入口继续保持零堆分配。

## 验证

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-targets --locked`：53 passed，1 ignored
- `cargo test --workspace --doc --locked`：1 passed
- `cargo test -p ziwei --test natal_exhaustive --release --locked -- --ignored`：1 passed
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked`
- `cargo bench -p ziwei_core --bench natal_allocations --locked`：两个入口均为 0 allocation / 0 byte
