### PR TITLE
feat(core): 开放已验证输入的只读访问

### DIFF
--- a/crates/ziwei/tests/natal_public_api.rs
+++ b/crates/ziwei/tests/natal_public_api.rs
@@ -1,9 +1,33 @@
 //! `ziwei` 门面公开的不可变 `Natal` 使用路径。
 
 use ziwei::{
-    Branch, Gender, PalaceName, StarCategory, StarGalaxy, StarName, Transformation, ZiweiBirth,
-    create_from_birth,
+    Branch, Gender, PalaceName, StarCategory, StarGalaxy, StarName, Stem, Transformation,
+    ZiweiBirth, ZiweiInput, create_from_birth,
 };
+
+#[test]
+fn facade_exposes_validated_birth_fields() {
+    let birth = ZiweiBirth::try_new(Gender::Yang, 2024, 0, 1, 0).expect("valid birth");
+
+    assert_eq!(birth.gender(), Gender::Yang);
+    assert_eq!(birth.year(), 2024);
+    assert_eq!(birth.month(), 0);
+    assert_eq!(birth.day(), 1);
+    assert_eq!(birth.hour(), 0);
+}
+
+#[test]
+fn facade_exposes_validated_preprocessed_input_fields() {
+    let input =
+        ZiweiInput::try_new(Gender::Yin, Stem::Yi, Branch::Chou, 11, 30, 11).expect("valid input");
+
+    assert_eq!(input.gender(), Gender::Yin);
+    assert_eq!(input.birth_stem(), Stem::Yi);
+    assert_eq!(input.birth_branch(), Branch::Chou);
+    assert_eq!(input.month(), 11);
+    assert_eq!(input.day(), 30);
+    assert_eq!(input.hour(), 11);
+}
 
 #[test]
 fn facade_exposes_the_read_only_natal_graph() {

--- a/crates/ziwei_core/src/input.rs
+++ b/crates/ziwei_core/src/input.rs
@@ -56,27 +56,27 @@ impl ZiweiBirth {
     }
 
     /// 命主性别。
-    pub(crate) const fn gender(self) -> Gender {
+    pub const fn gender(self) -> Gender {
         self.gender
     }
 
     /// 历法层归一化后的农历年序号，不是原始公历日期的年份。
-    pub(crate) const fn year(self) -> i32 {
+    pub const fn year(self) -> i32 {
         self.year
     }
 
     /// 农历月（正月 = 0）。
-    pub(crate) const fn month(self) -> u8 {
+    pub const fn month(self) -> u8 {
         self.month
     }
 
     /// 农历日（初一 = 1）。
-    pub(crate) const fn day(self) -> u8 {
+    pub const fn day(self) -> u8 {
         self.day
     }
 
     /// 时辰（子时 = 0）。
-    pub(crate) const fn hour(self) -> u8 {
+    pub const fn hour(self) -> u8 {
         self.hour
     }
 }
@@ -142,32 +142,32 @@ impl ZiweiInput {
     }
 
     /// 命主性别。
-    pub(crate) const fn gender(self) -> Gender {
+    pub const fn gender(self) -> Gender {
         self.gender
     }
 
     /// 出生年干。
-    pub(crate) const fn birth_stem(self) -> Stem {
+    pub const fn birth_stem(self) -> Stem {
         self.birth_stem
     }
 
     /// 生年地支。
-    pub(crate) const fn birth_branch(self) -> Branch {
+    pub const fn birth_branch(self) -> Branch {
         self.birth_branch
     }
 
     /// 农历月（正月 = 0）。
-    pub(crate) const fn month(self) -> u8 {
+    pub const fn month(self) -> u8 {
         self.month
     }
 
     /// 农历日（初一 = 1）。
-    pub(crate) const fn day(self) -> u8 {
+    pub const fn day(self) -> u8 {
         self.day
     }
 
     /// 时辰（子时 = 0）。
-    pub(crate) const fn hour(self) -> u8 {
+    pub const fn hour(self) -> u8 {
         self.hour
     }
 }

--- a/docs/adr/0001-lunar-birth-input-contract.md
+++ b/docs/adr/0001-lunar-birth-input-contract.md
@@ -6,7 +6,7 @@
 
 `ZiweiInput` / `create_from_input` 是预处理输入路径，注入边界见 ADR-0002。
 
-校验：`ZiweiBirth::try_new` 是唯一公开构造入口，负责校验 `year + 124` 可由 `i32` 表示，并校验月/日/时范围；字段和 getter 均不向 crate 外公开。`create_from_birth` 只接收已验证的 `ZiweiBirth`，因此直接返回命盘，不保留不可能发生的错误分支。
+校验：`ZiweiBirth::try_new` 是唯一公开构造入口，负责校验 `year + 124` 可由 `i32` 表示，并校验月/日/时范围；字段保持私有，对外提供 `gender`、`year`、`month`、`day`、`hour` 只读 getter。`create_from_birth` 只接收已验证的 `ZiweiBirth`，因此直接返回命盘，不保留不可能发生的错误分支。
 
 ## 否决过的做法
 

--- a/docs/adr/0010-result-type-invariants.md
+++ b/docs/adr/0010-result-type-invariants.md
@@ -2,7 +2,7 @@
 
 > 状态：**部分由 [ADR-0011](0011-immutable-natal-model.md) 取代。** 结果类型只能由内核装配的不变量仍有效；旧 `ZiweiFly` / `DecadeStep` 名称及存储形态以 ADR-0011 为准。
 
-引擎产出的多字段结果类型不得被外部自由构造。`Palace`、`Star`、`PalaceTransformation`、`Decade`、`DecadeYear` 的字段私有，只经 crate 内装配；对外只提供只读 getter。输入侧 `ZiweiBirth` / `ZiweiInput` 只公开校验构造，`DecadeIndex` 公开校验构造与只读值；不变量均由类型系统保证，不靠调用方自觉。
+引擎产出的多字段结果类型不得被外部自由构造。`Palace`、`Star`、`PalaceTransformation`、`Decade`、`DecadeYear` 的字段私有，只经 crate 内装配；对外只提供只读 getter。输入侧 `ZiweiBirth` / `ZiweiInput` 公开校验构造与只读 getter，`DecadeIndex` 公开校验构造与只读值；不变量均由类型系统保证，不靠调用方自觉。
 
 ## 哪些类型要封
 
@@ -23,6 +23,8 @@
 
 ```text
 // 外部：只读
+birth.gender() / birth.year() / birth.month() / birth.day() / birth.hour()
+input.gender() / input.birth_stem() / input.birth_branch() / input.month() / input.day() / input.hour()
 palace.role() / palace.branch() / palace.stem()
 transformation.source_branch() / transformation.transformation() / transformation.target_branch() / transformation.star_name()
 decade.index() / decade.ming_palace_branch() / decade.age_start() / decade.age_end()

--- a/docs/design/public-interface-and-domain-types.md
+++ b/docs/design/public-interface-and-domain-types.md
@@ -13,6 +13,13 @@ let natal = create_from_input(ZiweiInput::try_new(/* ... */)?);
 
 ## 读取接口
 
+两种已验证输入的字段保持私有，对外按值返回规范化后的原始事实：
+
+```text
+ZiweiBirth.gender() / year() / month() / day() / hour()
+ZiweiInput.gender() / birth_stem() / birth_branch() / month() / day() / hour()
+```
+
 多字段结果类型字段全部私有，按值返回小型 `Copy` 枚举和数字，按借用返回聚合：
 
 ```text

--- a/docs/guides/ziwei-core-reference.html
+++ b/docs/guides/ziwei-core-reference.html
@@ -1458,8 +1458,8 @@ QiSha, PoJun, ZuoFu, YouBi, WenChang, WenQu</code></pre>
               <table class="api-table">
                 <thead><tr><th>类型</th><th>公开入口 / getter</th><th>语义</th></tr></thead>
                 <tbody>
-                  <tr><td>ZiweiBirth</td><td>try_new(gender, year, month, day, hour)</td><td>带农历年序号的已验证输入</td></tr>
-                  <tr><td>ZiweiInput</td><td>try_new(gender, stem, branch, month, day, hour)</td><td>带生年干支、不带农历年序号的已验证输入</td></tr>
+                  <tr><td>ZiweiBirth</td><td>try_new / gender / year / month / day / hour</td><td>带农历年序号的已验证输入</td></tr>
+                  <tr><td>ZiweiInput</td><td>try_new / gender / birth_stem / birth_branch / month / day / hour</td><td>带生年干支、不带农历年序号的已验证输入</td></tr>
                   <tr><td>创建函数</td><td>create_from_birth / create_from_input</td><td>从两种已验证输入直接构造命盘</td></tr>
                   <tr><td>Natal</td><td>context / zodiac / palaces / decades</td><td>出生上下文、生肖、十二宫与大限</td></tr>
                   <tr><td>Natal</td><td>ming_palace_branch / shen_palace_name / shen_palace_branch / origin_palace_name / origin_palace_branch</td><td>命宫地支，以及身宫、来因宫的宫名与地支</td></tr>


### PR DESCRIPTION
## 变更

- 为 `ZiweiBirth` 开放 `gender`、`year`、`month`、`day`、`hour` 只读 getter
- 为 `ZiweiInput` 开放 `gender`、`birth_stem`、`birth_branch`、`month`、`day`、`hour` 只读 getter
- 保持字段私有、校验构造与内部转换行为不变
- 增加 facade 公共接口契约测试，并同步 ADR、设计文档和 API 指南

## 原因

已验证输入是公共值对象，调用方需要读取其中已经规范化的事实；只读 getter 在不削弱类型不变量的前提下提供这一能力。

## 影响

这是只读公共接口扩展，不增加 setter、builder 或新的构造路径，也不改变命盘计算结果。

## 验证

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo test --workspace --all-targets --locked`（55 passed，1 ignored）
- `cargo test --workspace --doc --locked`
- `cargo test -p ziwei --test natal_exhaustive --release --locked -- --ignored`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked`
- `git diff --check`