### PR TITLE
docs: 修正参考页指标标签偏移

### DIFF
--- a/docs/guides/ziwei-core-reference.html
+++ b/docs/guides/ziwei-core-reference.html
@@ -1081,8 +1081,8 @@
             <div class="hero-rule" aria-label="核心结构数量">
               <div><strong>12</strong><span>Palace · 寅为零 · 逆步</span></div>
               <div><strong>18</strong><span>StarName · 各一次</span></div>
-              <div><strong>4×12</strong><span>PalaceTransformation</span></div>
-              <div><strong>12×10</strong><span>DecadeYear</span></div>
+              <div><strong>4×12</strong><span>Palace<wbr>Transformation</span></div>
+              <div><strong>12×10</strong><span>Decade<wbr>Year</span></div>
             </div>
           </div>
           <div class="orbit-wrap" aria-label="十二宫以寅为零，按寅、卯、辰、巳、午、未、申、酉、戌、亥、子、丑逆步排列">


### PR DESCRIPTION
## 变更

- 为 `PalaceTransformation` 与 `DecadeYear` 增加不改变文本内容的自然换行点
- 防止参考页首屏指标在中等宽度下水平溢出并覆盖相邻标签

## 原因

指标区使用四列布局，长 CamelCase 标识缺少可换行位置，在可用列宽不足时会侵入下一列。

## 影响

仅调整 `ziwei-core-reference.html` 的展示标记，不改变领域模型、文档含义或运行时代码。

## 验证

- Playwright 验证 375–1440px 多个视口与断点边缘
- `git diff --check`