### PR TITLE
添加 ziwei_query 性能基准

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,6 +486,8 @@ dependencies = [
 name = "ziwei_query"
 version = "0.1.0"
 dependencies = [
+ "allocation-counter",
+ "criterion",
  "ziwei_core",
 ]
 

--- a/crates/ziwei_query/Cargo.toml
+++ b/crates/ziwei_query/Cargo.toml
@@ -12,5 +12,17 @@ repository.workspace = true
 [dependencies]
 ziwei_core.workspace = true
 
+[dev-dependencies]
+allocation-counter.workspace = true
+criterion.workspace = true
+
+[[bench]]
+name = "query"
+harness = false
+
+[[bench]]
+name = "query_allocations"
+harness = false
+
 [lints]
 workspace = true

--- a/crates/ziwei_query/benches/query.rs
+++ b/crates/ziwei_query/benches/query.rs
@@ -1,0 +1,44 @@
+//! Representative `ziwei_query` latency baselines.
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+
+mod support;
+
+use support::{
+    PALACE_QUERY_COUNT, STAR_QUERY_COUNT, YEAR_QUERY_COUNT, lookup_decade_years_by_age,
+    lookup_decade_years_by_lunar_year, lookup_incoming_palace_transformations, lookup_palaces,
+    lookup_stars, representative_cases,
+};
+
+fn benchmark_query(c: &mut Criterion) {
+    let cases = representative_cases();
+    let mut group = c.benchmark_group("query/sexagenary_cycle");
+
+    group.throughput(elements(PALACE_QUERY_COUNT));
+    group.bench_function("palace", |b| b.iter(|| lookup_palaces(&cases)));
+
+    group.throughput(elements(STAR_QUERY_COUNT));
+    group.bench_function("star", |b| b.iter(|| lookup_stars(&cases)));
+
+    group.throughput(elements(PALACE_QUERY_COUNT));
+    group.bench_function("incoming_palace_transformations", |b| {
+        b.iter(|| lookup_incoming_palace_transformations(&cases));
+    });
+
+    group.throughput(elements(YEAR_QUERY_COUNT));
+    group.bench_function("decade_year_at_age", |b| {
+        b.iter(|| lookup_decade_years_by_age(&cases));
+    });
+    group.bench_function("decade_year_at_lunar_year", |b| {
+        b.iter(|| lookup_decade_years_by_lunar_year(&cases));
+    });
+
+    group.finish();
+}
+
+fn elements(count: usize) -> Throughput {
+    Throughput::Elements(u64::try_from(count).expect("query count fits in u64"))
+}
+
+criterion_group!(benches, benchmark_query);
+criterion_main!(benches);

--- a/crates/ziwei_query/benches/query_allocations.rs
+++ b/crates/ziwei_query/benches/query_allocations.rs
@@ -1,0 +1,44 @@
+//! Representative `ziwei_query` allocation baselines.
+
+use allocation_counter::{AllocationInfo, measure};
+
+mod support;
+
+use support::{
+    CASE_COUNT, PALACE_QUERY_COUNT, STAR_QUERY_COUNT, YEAR_QUERY_COUNT, lookup_decade_years_by_age,
+    lookup_decade_years_by_lunar_year, lookup_incoming_palace_transformations, lookup_palaces,
+    lookup_stars, representative_cases,
+};
+
+fn print_allocations(name: &str, allocations: AllocationInfo) {
+    println!(
+        "{name}: total_allocations={}, total_bytes={}, peak_allocations={}, peak_bytes={}",
+        allocations.count_total,
+        allocations.bytes_total,
+        allocations.count_max,
+        allocations.bytes_max,
+    );
+}
+
+fn main() {
+    let cases = representative_cases();
+    println!(
+        "workload: cases={CASE_COUNT}, palace_queries={PALACE_QUERY_COUNT}, star_queries={STAR_QUERY_COUNT}, year_queries={YEAR_QUERY_COUNT}"
+    );
+
+    let _ = measure(|| {});
+    print_allocations("palace", measure(|| lookup_palaces(&cases)));
+    print_allocations("star", measure(|| lookup_stars(&cases)));
+    print_allocations(
+        "incoming_palace_transformations",
+        measure(|| lookup_incoming_palace_transformations(&cases)),
+    );
+    print_allocations(
+        "decade_year_at_age",
+        measure(|| lookup_decade_years_by_age(&cases)),
+    );
+    print_allocations(
+        "decade_year_at_lunar_year",
+        measure(|| lookup_decade_years_by_lunar_year(&cases)),
+    );
+}

--- a/crates/ziwei_query/benches/support/mod.rs
+++ b/crates/ziwei_query/benches/support/mod.rs
@@ -1,0 +1,116 @@
+use std::hint::black_box;
+
+use ziwei_core::{Gender, Natal, PalaceName, StarName, ZiweiBirth, create_from_birth};
+use ziwei_query::query;
+
+pub(crate) const CASE_COUNT: usize = 60;
+pub(crate) const PALACE_QUERY_COUNT: usize = CASE_COUNT * PalaceName::ALL.len();
+pub(crate) const STAR_QUERY_COUNT: usize = CASE_COUNT * StarName::ALL.len();
+pub(crate) const YEAR_QUERY_COUNT: usize = CASE_COUNT * 120;
+
+pub(crate) struct QueryCase {
+    natal: Natal,
+    ages: [u8; 120],
+    lunar_years: [i32; 120],
+}
+
+pub(crate) fn representative_cases() -> [QueryCase; CASE_COUNT] {
+    std::array::from_fn(|index| {
+        let birth = ZiweiBirth::try_new(
+            gender(index),
+            1984 + i32::try_from(index).expect("case index fits in i32"),
+            month(index),
+            day(index),
+            hour(index),
+        )
+        .expect("representative birth is valid");
+        let natal = create_from_birth(birth);
+        let ages = std::array::from_fn(|year_index| {
+            natal.decades()[year_index / 10].years()[year_index % 10].age()
+        });
+        let lunar_years = std::array::from_fn(|year_index| {
+            natal.decades()[year_index / 10].years()[year_index % 10]
+                .year()
+                .expect("birth-based natal has absolute lunar years")
+        });
+
+        QueryCase {
+            natal,
+            ages,
+            lunar_years,
+        }
+    })
+}
+
+pub(crate) fn lookup_palaces(cases: &[QueryCase; CASE_COUNT]) {
+    for case in black_box(cases) {
+        let scope = query(black_box(&case.natal)).natal();
+        for name in black_box(PalaceName::ALL) {
+            let _ = black_box(scope.palace(black_box(name)));
+        }
+    }
+}
+
+pub(crate) fn lookup_stars(cases: &[QueryCase; CASE_COUNT]) {
+    for case in black_box(cases) {
+        let scope = query(black_box(&case.natal)).natal();
+        for name in black_box(StarName::ALL) {
+            let _ = black_box(scope.star(black_box(name)));
+        }
+    }
+}
+
+pub(crate) fn lookup_incoming_palace_transformations(cases: &[QueryCase; CASE_COUNT]) {
+    for case in black_box(cases) {
+        let scope = query(black_box(&case.natal)).natal();
+        for palace in scope.palaces() {
+            black_box(palace.incoming_palace_transformations().count());
+        }
+    }
+}
+
+pub(crate) fn lookup_decade_years_by_age(cases: &[QueryCase; CASE_COUNT]) {
+    for case in black_box(cases) {
+        let query = query(black_box(&case.natal));
+        for age in black_box(&case.ages) {
+            let _ = black_box(
+                query
+                    .decade_year_at_age(black_box(*age))
+                    .expect("representative age is covered by the natal decades"),
+            );
+        }
+    }
+}
+
+pub(crate) fn lookup_decade_years_by_lunar_year(cases: &[QueryCase; CASE_COUNT]) {
+    for case in black_box(cases) {
+        let query = query(black_box(&case.natal));
+        for year in black_box(&case.lunar_years) {
+            let _ = black_box(
+                query
+                    .decade_year_at_lunar_year(black_box(*year))
+                    .expect("representative lunar year is covered by the natal decades"),
+            );
+        }
+    }
+}
+
+const fn gender(index: usize) -> Gender {
+    if index.rem_euclid(4) < 2 {
+        Gender::Yang
+    } else {
+        Gender::Yin
+    }
+}
+
+fn month(index: usize) -> u8 {
+    u8::try_from((index * 5).rem_euclid(12)).expect("month fits in u8")
+}
+
+fn day(index: usize) -> u8 {
+    u8::try_from((index * 7).rem_euclid(30) + 1).expect("day fits in u8")
+}
+
+fn hour(index: usize) -> u8 {
+    u8::try_from((index * 7 + 3).rem_euclid(12)).expect("hour fits in u8")
+}


### PR DESCRIPTION
## 变更

- 为 ziwei_query 添加 Criterion 延迟基准
- 添加零分配基准，覆盖宫位、星曜、飞入四化及大限年份查询
- 使用 60 张连续干支年命盘，排除命盘构造与测试数据准备成本

## 结果

- 宫位查询约 2.67 ns
- 星曜查询约 9.28 ns
- 单宫飞入四化约 217 ns
- 大限年份查询约 8.50 至 11.14 ns
- 所有受测查询均为零堆分配

## 验证

- cargo test --workspace --all-targets：65 passed，1 ignored
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- git diff --check