### PR TITLE
refactor(core): 移除生产依赖

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,12 +39,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
-name = "arrayvec"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,7 +472,6 @@ name = "ziwei_core"
 version = "0.1.0"
 dependencies = [
  "allocation-counter",
- "arrayvec",
  "criterion",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/matharts/ziwei"
 
 [workspace.dependencies]
 allocation-counter = "0.8.1"
-arrayvec = "0.7.8"
 criterion = { version = "0.8.2", default-features = false, features = ["cargo_bench_support"] }
 ziwei = { path = "crates/ziwei" }
 ziwei_analysis = { path = "crates/ziwei_analysis" }

--- a/crates/ziwei_core/Cargo.toml
+++ b/crates/ziwei_core/Cargo.toml
@@ -9,9 +9,6 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
-[dependencies]
-arrayvec.workspace = true
-
 [dev-dependencies]
 allocation-counter.workspace = true
 criterion.workspace = true

--- a/crates/ziwei_core/src/domain/palace.rs
+++ b/crates/ziwei_core/src/domain/palace.rs
@@ -1,16 +1,63 @@
 //! 十二宫名、宫位及宫位四化关系。
 
-use arrayvec::ArrayVec;
+use core::fmt;
 
 use super::{
     branch::Branch,
-    star::{Star, StarName},
+    star::{Star, StarCategory, StarGalaxy, StarName, StarSelfTransformations},
     stem::Stem,
     transformation::Transformation,
 };
 
-pub(crate) const MAX_STARS_PER_PALACE: usize = 6;
-pub(crate) type PalaceStars = ArrayVec<Star, MAX_STARS_PER_PALACE>;
+const MAX_STARS_PER_PALACE: usize = 6;
+
+/// 一宫最多六星的无堆分配存储。
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PalaceStars {
+    stars: [Star; MAX_STARS_PER_PALACE],
+    len: u8,
+}
+
+impl Default for PalaceStars {
+    fn default() -> Self {
+        Self {
+            stars: [Self::unused_star_slot(); MAX_STARS_PER_PALACE],
+            len: 0,
+        }
+    }
+}
+
+impl fmt::Debug for PalaceStars {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_slice().fmt(f)
+    }
+}
+
+impl PalaceStars {
+    const fn unused_star_slot() -> Star {
+        Star::new(
+            StarName::ZiWei,
+            StarCategory::Major,
+            Some(StarGalaxy::Central),
+            None,
+            StarSelfTransformations::new(None, None),
+        )
+    }
+
+    pub(crate) fn try_push(&mut self, star: Star) -> Result<(), Star> {
+        let Some(slot) = self.stars.get_mut(usize::from(self.len)) else {
+            return Err(star);
+        };
+
+        *slot = star;
+        self.len += 1;
+        Ok(())
+    }
+
+    pub(crate) fn as_slice(&self) -> &[Star] {
+        &self.stars[..usize::from(self.len)]
+    }
+}
 
 /// 十二宫名，自命宫起按经典逆布次序排列。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -198,7 +245,36 @@ impl Palace {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::{StarCategory, StarGalaxy, star::StarSelfTransformations};
+    fn star(name: StarName) -> Star {
+        Star::new(
+            name,
+            StarCategory::Major,
+            Some(StarGalaxy::Central),
+            None,
+            StarSelfTransformations::new(None, None),
+        )
+    }
+
+    #[test]
+    fn palace_stars_preserve_order_and_reject_a_seventh_star() {
+        let mut stars = PalaceStars::default();
+        for name in StarName::ALL.into_iter().take(MAX_STARS_PER_PALACE) {
+            stars
+                .try_push(star(name))
+                .expect("the first six stars fit in a palace");
+        }
+
+        let seventh = star(StarName::ALL[MAX_STARS_PER_PALACE]);
+        assert_eq!(stars.try_push(seventh), Err(seventh));
+        assert_eq!(
+            stars
+                .as_slice()
+                .iter()
+                .map(|star| star.name())
+                .collect::<Vec<_>>(),
+            StarName::ALL[..MAX_STARS_PER_PALACE]
+        );
+    }
 
     #[test]
     fn palace_exposes_read_only_nested_facts() {
@@ -217,8 +293,8 @@ mod tests {
             Branch::Zi,
             StarName::ZiWei,
         );
-        let mut stars = PalaceStars::new();
-        stars.push(star);
+        let mut stars = PalaceStars::default();
+        stars.try_push(star).expect("one star fits in a palace");
         let palace = Palace::new(
             PalaceName::Ming,
             Branch::Zi,

--- a/crates/ziwei_core/src/natal.rs
+++ b/crates/ziwei_core/src/natal.rs
@@ -129,7 +129,7 @@ fn create_from_context(context: NatalContext) -> Natal {
         &branches_by_star,
     );
 
-    let mut stars_by_branch: [PalaceStars; 12] = std::array::from_fn(|_| PalaceStars::new());
+    let mut stars_by_branch = [PalaceStars::default(); 12];
     for name in StarName::ALL {
         let branch = branches_by_star[name.index()];
         let star = Star::new(
@@ -145,7 +145,7 @@ fn create_from_context(context: NatalContext) -> Natal {
     }
 
     // 对外宫序固定为寅至丑。端到端基准与发布构建汇编均显示：显式展开可直接组装
-    // 672 B 宫位数组，而 `array::from_fn` 会保留一次整数组搬移；实际构造仍集中在
+    // 固定宫位数组，而 `array::from_fn` 会保留一次整数组搬移；实际构造仍集中在
     // `take_palace_at_branch`，避免十二份规则实现。
     let mut take_palace = |branch| {
         take_palace_at_branch(


### PR DESCRIPTION
## 变更

- 从 workspace 与 ziwei_core 移除 arrayvec
- 使用私有定长 PalaceStars 保持每宫最多六星的不变量
- 保持星曜顺序、只读切片接口和零堆分配构盘
- 增加容量、顺序及第七颗星拒绝测试

## 原因

ziwei_core 需要保持零生产依赖，同时不能退回会产生堆分配的 Vec 实现。

## 影响

公开接口与领域行为不变；ziwei_core 的 normal dependency tree 为空。

## 验证

- cargo test --workspace --all-targets：71 passed，1 ignored
- release 穷举测试：518,400 种合法输入通过
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo fmt --all --check
- 两条构盘入口均保持 0 allocation