### PR TITLE
docs(core): 记录十二宫组装基准

### DIFF
--- a/crates/ziwei_core/src/natal.rs
+++ b/crates/ziwei_core/src/natal.rs
@@ -144,9 +144,9 @@ fn create_from_context(context: NatalContext) -> Natal {
             .expect("a palace contains at most six supported stars");
     }
 
-    // 对外宫序固定为寅至丑。端到端基准与发布构建汇编均显示：显式展开可直接组装
-    // 固定宫位数组，而 `array::from_fn` 会保留一次整数组搬移；实际构造仍集中在
-    // `take_palace_at_branch`，避免十二份规则实现。
+    // 对外宫序固定为寅至丑。rustc 1.97.1 下改用 `PALACE_ORDER.map` 会使 `natal`
+    // 两个端到端构盘基准稳定慢约 9%–11%，因此在此显式展开；宫位构造规则仍集中在
+    // `take_palace_at_branch`。
     let mut take_palace = |branch| {
         take_palace_at_branch(
             branch,


### PR DESCRIPTION
## 变更

- 更新十二宫显式组装处的性能说明
- 记录当前 rustc 1.97.1 下 `PALACE_ORDER.map` 的实测回退范围
- 明确重复仅限固定宫序，宫位构造规则仍集中在 `take_palace_at_branch`

## 原因

原注释只泛称端到端基准与汇编证据，缺少可判断该优化是否仍值得保留的量化依据。重新在当前零依赖存储布局上做双向 Criterion 比较后，标准数组遍历仍存在稳定且显著的端到端回退。

## 性能证据

- `PALACE_ORDER.map` 相比显式展开：两个构盘入口均慢约 11.3%
- 恢复显式展开反向比较：`create_from_input` 提升约 9.9%，`create_from_birth` 提升约 8.5%
- 两种实现均为 0 allocation，`Natal` 均为 2280 B

## 验证

- `cargo test --workspace --all-targets`：71 passed，1 ignored
- release 穷举测试：518,400 种合法输入通过
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

本 PR 仅修改注释，不改变生产行为。